### PR TITLE
Removed the memory limit which caused issues in deployment

### DIFF
--- a/dp-dataset-exporter-xlsx.nomad
+++ b/dp-dataset-exporter-xlsx.nomad
@@ -28,7 +28,6 @@ job "dp-dataset-exporter-xlsx" {
 
         args = [
           "java",
-          "-Xmx2048m",
           "-jar",
           "dp-dataset-exporter-xlsx.jar",
         ]


### PR DESCRIPTION
### What

nomad plan was allowing the java process to claim too much memory. This caused docker to error out.

### How to review
Review the nomad plan

### Who can review

anyone
