### PR TITLE
Update request endpoint to update filter resource

### DIFF
--- a/src/main/java/dp/api/FilterAPIClient.java
+++ b/src/main/java/dp/api/FilterAPIClient.java
@@ -32,7 +32,7 @@ public class FilterAPIClient {
     private ObjectMapper objectMapper;
 
     public void addXLSXFile(final String id, final String s3Location, final long size) throws JsonProcessingException {
-        final String url = UriComponentsBuilder.fromHttpUrl(filterAPIURL + "/filters/{filterId}").buildAndExpand(id).toUriString();
+        final String url = UriComponentsBuilder.fromHttpUrl(filterAPIURL + "/filter-outputs/{filterId}").buildAndExpand(id).toUriString();
         final HttpHeaders headers = new HttpHeaders();
         final String sizeToString = Long.toString(size);
         headers.add("internal-token", token);


### PR DESCRIPTION
### What

Filter blueprint resource can be updated and submitted as many times as
the user wants. On submission a filter output resource is created and
will be updated with download urls by the backend export process. When
submitting a filter blueprint, the response body will return a link to
the filter output resource.

Also include unit test coverage.

### How to review

Check logic makes sense and follows spec. Make sure all unit tests pass. Changes include using new endpoint to update a filter output instead of a filter job.

### Who can review

Team  B

Notes:

Pull request needs to go in with the following PR's:

FE services:

* go-ns (filter-api client): ONSdigital/go-ns#38 (review)
* frontend-filter-dataset-controller: https://github.com/ONSdigital/dp-frontend-filter-dataset-controller/pull/37/files
* frontend-dataset-controller: ONSdigital/dp-frontend-dataset-controller#19 (review)
* frontend-router: https://github.com/ONSdigital/dp-frontend-router/pull/47/files

BE services:

* dp-filter-api: https://github.com/ONSdigital/dp-filter-api/pull/38
* dp-api-tests: ONSdigital/dp-api-tests#9
* dp-dataset-exporter: https://github.com/ONSdigital/dp-dataset-exporter/pull/13
