### PR TITLE
Use the configured environment hostname for the dataset API.

### DIFF
--- a/src/main/java/dp/api/dataset/DatasetAPIClient.java
+++ b/src/main/java/dp/api/dataset/DatasetAPIClient.java
@@ -6,12 +6,13 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Component;
 import org.springframework.web.client.RestClientException;
 import org.springframework.web.client.RestTemplate;
-import org.springframework.web.util.UriComponentsBuilder;
+
+import java.net.MalformedURLException;
+import java.net.URL;
 
 @Component
 public class DatasetAPIClient {
@@ -30,14 +31,10 @@ public class DatasetAPIClient {
     @Autowired
     private ObjectMapper objectMapper;
 
-    public Metadata getMetadata(final String datasetVersionURL) {
+    public Metadata getMetadata(final String datasetVersionURL) throws MalformedURLException {
 
-        final String url = UriComponentsBuilder
-                .fromHttpUrl(datasetVersionURL + "/metadata")
-                .build().toUriString();
-
-        final HttpHeaders headers = new HttpHeaders();
-        headers.add("internal-token", token);
+        final String versionPath = new URL(datasetVersionURL).getPath();
+        final String url = new URL(datasetAPIURL + versionPath + "/metadata").toString();
 
         LOGGER.info("getting dataset version data from the dataset api, url : {}", url);
 


### PR DESCRIPTION
### What

Use the configured environment hostname for the dataset API.

Using the hostname returned from the filter API (localhost) does not
work when running in a docker container, so using the configured nomad
host instead.
