### PR TITLE
Fix number formatting in XLSX.

### DIFF
--- a/src/main/java/dp/xlsx/DatasetFormatter.java
+++ b/src/main/java/dp/xlsx/DatasetFormatter.java
@@ -5,6 +5,7 @@ import org.apache.poi.ss.usermodel.Cell;
 import org.apache.poi.ss.usermodel.CellStyle;
 import org.apache.poi.ss.usermodel.Row;
 import org.apache.poi.ss.usermodel.Sheet;
+import org.springframework.util.StringUtils;
 
 import java.util.Collections;
 import java.util.HashMap;
@@ -70,14 +71,24 @@ class DatasetFormatter {
             for (String timeTitle : timeLabels) {
                 Row row = timeRows.get(timeTitle);
                 Cell obs = row.createCell(g + columnOffset);
-                obs.setCellStyle(numberStyle);
+
                 final String value = groups.get(g).getObservation(timeTitle);
-                if (value != null) {
-                    try {
-                        obs.setCellValue(Double.parseDouble(value));
-                    } catch (NumberFormatException e) {
-                        obs.setCellValue("");
-                    }
+
+                if (StringUtils.isEmpty(value)) {
+                    obs.setCellValue("");
+                    continue;
+                }
+
+                if (value.contains(".")) {
+                    obs.setCellStyle(numberStyle); // apply decimal formatting if there is a decimal
+                } else {
+                    obs.setCellStyle(titleStyle);
+                }
+
+                try {
+                    obs.setCellValue(Double.parseDouble(value));
+                } catch (NumberFormatException e) {
+                    obs.setCellValue("");
                 }
             }
         }

--- a/src/main/java/dp/xlsx/XLSXConverter.java
+++ b/src/main/java/dp/xlsx/XLSXConverter.java
@@ -88,7 +88,7 @@ public class XLSXConverter {
         final Font font = wb.createFont();
         font.setFontName("Arial-Number");
         font.setFontHeightInPoints((short) 14);
-        style.setDataFormat(wb.createDataFormat().getFormat(".#############################"));
+        style.setDataFormat(wb.createDataFormat().getFormat("0.0############################"));
         style.setFont(font);
         style.setWrapText(true);
         style.setVerticalAlignment(VerticalAlignment.TOP);


### PR DESCRIPTION
### What

All numbers should be displayed as they are imported. Decimal places
should be maintained, and numbers with '.0' should end as such. Numbers
with no decimal places should be displayed with no decimal places.

Cases supported:
0.0
0
-0
1.0
1
1.123

Cases not supported:
1.1230 (last zero is trimmed)

### How to review

Review code changes

### Who can review

Anyone
