### PR TITLE
Order date labels chronologically for CPI.

### DIFF
--- a/src/main/java/dp/xlsx/DatasetFormatter.java
+++ b/src/main/java/dp/xlsx/DatasetFormatter.java
@@ -7,6 +7,7 @@ import org.apache.poi.ss.usermodel.Row;
 import org.apache.poi.ss.usermodel.Sheet;
 import org.springframework.util.StringUtils;
 
+import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -38,8 +39,7 @@ class DatasetFormatter {
         final List<Group> groups = file.groupData();
         Collections.sort(groups);
 
-        final List<String> timeLabels = file.getUniqueTimeLabels();
-        Collections.sort(timeLabels);
+        final Collection<String> timeLabels = file.getOrderedTimeLabels();
 
         final Map<String, Row> timeRows = new HashMap<>();
         int columnOffset = 0;
@@ -48,12 +48,15 @@ class DatasetFormatter {
         rowOffset = addMetadata(sheet, datasetMetadata, headingStyle, columnOffset, rowOffset);
 
         // Start off by placing the time on all rows
-        for (int i = 0; i < timeLabels.size(); i++) {
+
+        int i = 0;
+        for (String timeLabel : timeLabels) {
             Row row = sheet.createRow(i + rowOffset + 1);
             Cell cell = row.createCell(columnOffset);
             cell.setCellStyle(titleStyle);
-            cell.setCellValue(timeLabels.get(i));
-            timeRows.put(timeLabels.get(i), row);
+            cell.setCellValue(timeLabel);
+            timeRows.put(timeLabel, row);
+            i++;
         }
 
         columnOffset += 1;
@@ -115,4 +118,5 @@ class DatasetFormatter {
         rowOffset++;
         return rowOffset;
     }
+
 }

--- a/src/main/java/dp/xlsx/DateLabel.java
+++ b/src/main/java/dp/xlsx/DateLabel.java
@@ -1,0 +1,27 @@
+package dp.xlsx;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Helper for working with date labels in v4 files.
+ */
+public class DateLabel {
+
+    private static final Map<String, String> DATE_FORMAT_REGEXPS = new HashMap<String, String>() {{
+        put("^\\w{3}-\\d{2}$", "MMM-yy");
+    }};
+
+    /**
+     * Take a date label and return it's format if it's recognised.
+     */
+    public static String determineDateFormat(String dateString) {
+
+        for (String regexp : DATE_FORMAT_REGEXPS.keySet()) {
+            if (dateString.toLowerCase().matches(regexp)) {
+                return DATE_FORMAT_REGEXPS.get(regexp);
+            }
+        }
+        return null; // Unknown format.
+    }
+}

--- a/src/test/java/dp/xlsx/DatasetFormatterTest.java
+++ b/src/test/java/dp/xlsx/DatasetFormatterTest.java
@@ -29,7 +29,26 @@ public class DatasetFormatterTest {
     final Sheet sheet = wb.createSheet("Test");
 
     @Test
-    public void timeValuesAreOrderedAlphabetically() throws IOException {
+    public void timeValuesAreOrderedAlphabeticallyWhenUnrecognised() throws IOException {
+
+        // Given some V4 input data
+        String csvHeader = "V4_0,Time_codelist,Time,Geography_codelist,Geography,cpi1dim1aggid,Aggregate\n";
+        String csvRow = "45.2,Month,January-96,K02000001,Great Britain,cpi1dim1A0,CPI (overall index)\n";
+        String csvRow2 = "86.9,Month,February-96,K02000001,Great Britain,cpi1dim1A0,CPI (overall index)\n";
+        String csvContent = csvHeader + csvRow + csvRow2;
+
+        InputStream inputStream = new ByteArrayInputStream(csvContent.getBytes());
+        final V4File file = new V4File(inputStream);
+
+        // When format is called
+        datasetFormatter.format(sheet, file, datasetMetadata, style, style, style);
+
+        assertThat(sheet.getRow(metadataRows + 1).getCell(0).getStringCellValue()).isEqualTo("February-96");
+        assertThat(sheet.getRow(metadataRows + 2).getCell(0).getStringCellValue()).isEqualTo("January-96");
+    }
+
+    @Test
+    public void timeValuesAreOrderedChronologicallyWhenRecognised() throws IOException {
 
         // Given some V4 input data
         String csvHeader = "V4_0,Time_codelist,Time,Geography_codelist,Geography,cpi1dim1aggid,Aggregate\n";
@@ -43,8 +62,8 @@ public class DatasetFormatterTest {
         // When format is called
         datasetFormatter.format(sheet, file, datasetMetadata, style, style, style);
 
-        assertThat(sheet.getRow(metadataRows + 1).getCell(0).getStringCellValue()).isEqualTo("Feb-96");
-        assertThat(sheet.getRow(metadataRows + 2).getCell(0).getStringCellValue()).isEqualTo("Jan-96");
+        assertThat(sheet.getRow(metadataRows + 1).getCell(0).getStringCellValue()).isEqualTo("Jan-96");
+        assertThat(sheet.getRow(metadataRows + 2).getCell(0).getStringCellValue()).isEqualTo("Feb-96");
     }
 
     @Test
@@ -144,7 +163,7 @@ public class DatasetFormatterTest {
         Cell cell = sheet.getRow(metadataRows + 1).getCell(1);
 
         assertThat(cell.getCellTypeEnum()).isEqualTo(CellType.NUMERIC);
-        assertThat(cell.getNumericCellValue()).isEqualTo("88.0");
+        assertThat(cell.getNumericCellValue()).isEqualTo(88.0);
     }
 
     @Test
@@ -166,7 +185,7 @@ public class DatasetFormatterTest {
         Cell cell = sheet.getRow(metadataRows + 1).getCell(1);
 
         assertThat(cell.getCellTypeEnum()).isEqualTo(CellType.NUMERIC);
-        assertThat(cell.getNumericCellValue()).isEqualTo(88);
+        assertThat(cell.getNumericCellValue()).isEqualTo(88.0);
     }
 
     private CellStyle createStyle(Workbook wb) {

--- a/src/test/java/dp/xlsx/DateLabelTest.java
+++ b/src/test/java/dp/xlsx/DateLabelTest.java
@@ -1,0 +1,33 @@
+package dp.xlsx;
+
+import org.assertj.core.api.Assertions;
+import org.junit.Test;
+
+public class DateLabelTest {
+
+    @Test
+    public void determineFormat_MMM_yy() throws Exception {
+
+        // Given a date label with the format MMM-yy
+        String dateString = "Feb-96";
+
+        // When determine is called
+        String format = DateLabel.determineDateFormat(dateString);
+
+        // Then the expected format is returned
+        Assertions.assertThat(format).isEqualTo("MMM-yy");
+    }
+
+    @Test
+    public void determineFormat_unrecognised() throws Exception {
+
+        // Given a date label with an unrecognised format
+        String dateString = "some-date-format-not-recognised";
+
+        // When determine is called
+        String format = DateLabel.determineDateFormat(dateString);
+
+        // Then null is returned
+        Assertions.assertThat(format).isNull();
+    }
+}

--- a/src/test/java/dp/xlsx/V4FileTest.java
+++ b/src/test/java/dp/xlsx/V4FileTest.java
@@ -2,8 +2,11 @@ package dp.xlsx;
 
 import org.junit.Test;
 
+import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -43,5 +46,51 @@ public class V4FileTest {
             final Group group = file.groupData().get(0);
             assertThat(group.getTitle()).isEqualTo("K02000001\n" + "CPI (overall index) (cpi1dim1A0)");
         }
+    }
+
+    @Test
+    public void orderedTimeLabels() throws IOException {
+
+        // Given v4 data with time labels in a recognised format.
+        String csvHeader = "V4_0,Time_codelist,Time,Geography_codelist,Geography,cpi1dim1aggid,Aggregate\n";
+        String csvRow1 = "88,Month,Oct-00,K02000001,,cpi1dim1A0,CPI (overall index)\n";
+        String csvRow2 = "88,Month,Jan-96,K02000001,,cpi1dim1A0,CPI (overall index)\n";
+        String csvRow3 = "88,Month,Apr-17,K02000001,,cpi1dim1A0,CPI (overall index)\n";
+        String csvContent = csvHeader + csvRow1 + csvRow2 + csvRow3;
+
+        InputStream inputStream = new ByteArrayInputStream(csvContent.getBytes());
+        final V4File file = new V4File(inputStream);
+        file.groupData();
+
+        // When getOrderedTimeLabels is called.
+        List<String> labels = new ArrayList<>(file.getOrderedTimeLabels());
+
+        // Then the labels are provided in chronological order.
+        assertThat(labels.get(0)).isEqualTo("Jan-96");
+        assertThat(labels.get(1)).isEqualTo("Oct-00");
+        assertThat(labels.get(2)).isEqualTo("Apr-17");
+    }
+
+    @Test
+    public void orderedTimeLabels_unrecognisedFormat() throws IOException {
+
+        // Given v4 data with time labels in an unrecognised format.
+        String csvHeader = "V4_0,Time_codelist,Time,Geography_codelist,Geography,cpi1dim1aggid,Aggregate\n";
+        String csvRow1 = "88,Month,10-00,K02000001,,cpi1dim1A0,CPI (overall index)\n";
+        String csvRow2 = "88,Month,01-96,K02000001,,cpi1dim1A0,CPI (overall index)\n";
+        String csvRow3 = "88,Month,11-17,K02000001,,cpi1dim1A0,CPI (overall index)\n";
+        String csvContent = csvHeader + csvRow1 + csvRow2 + csvRow3;
+
+        InputStream inputStream = new ByteArrayInputStream(csvContent.getBytes());
+        final V4File file = new V4File(inputStream);
+        file.groupData();
+
+        // When getOrderedTimeLabels is called.
+        List<String> labels = new ArrayList<>(file.getOrderedTimeLabels());
+
+        // Then the labels are provided in alphabetical order.
+        assertThat(labels.get(0)).isEqualTo("01-96");
+        assertThat(labels.get(1)).isEqualTo("10-00");
+        assertThat(labels.get(2)).isEqualTo("11-17");
     }
 }


### PR DESCRIPTION
### What

Order date labels chronologically for CPI.

Date formats are currently ordered alphabetically. This change allows
formats to be recognised and parsed allowing the dates to be sorted
chronologically.

### How to review

Review code + tests

### Who can review

Anyone
