### PR TITLE
Order dimension headers alphabetically in the XLSX.

### DIFF
--- a/src/main/java/dp/xlsx/DatasetFormatter.java
+++ b/src/main/java/dp/xlsx/DatasetFormatter.java
@@ -64,16 +64,7 @@ class DatasetFormatter {
         // add dimension names in the corner of the table
         Cell cell = title.createCell(columnOffset);
         cell.setCellStyle(valueRightAlign);
-
-        if (datasetMetadata.getDimensions() != null) {
-            String dimensionNames = datasetMetadata.getDimensions()
-                    .stream()
-                    .skip(1) // skip geography dimension
-                    .map(d -> StringUtils.capitalize(d.getName()))
-                    .collect(Collectors.joining("\n"));
-
-            cell.setCellValue(dimensionNames);
-        }
+        cell.setCellValue(file.getDimensionsTitle());
 
         columnOffset += 1;
 

--- a/src/main/java/dp/xlsx/Group.java
+++ b/src/main/java/dp/xlsx/Group.java
@@ -4,13 +4,14 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.TreeMap;
 
 /**
  * A single unique combination of dimension options, and its associated observations.
  */
 public class Group implements Comparable<Group> {
 
-    private List<String> groupValues; // the unique dimension options
+    private Map<String, String> dimensionOptions; // the unique dimension options
     private Map<String, String> observations; // time: observation
 
     /**
@@ -19,34 +20,35 @@ public class Group implements Comparable<Group> {
      * @param data   A row from a V4 file
      * @param offset The v4 file offset
      */
-    Group(String[] data, int offset) {
+    Group(String[] data, String[] header, int offset) {
 
         final int labelOffset = 2; // Skip the code and get the label when iterating columns
-        groupValues = new ArrayList<>();
+        dimensionOptions = new TreeMap<>();
         observations = new HashMap<>();
         int columnOffset = offset + 3; // skip the observation, time code and time label
 
-        // read geography code and label
-        String value = data[columnOffset];
+        String dimension = header[columnOffset];
+        String option = data[columnOffset];
 
-        if ("".equals(value)) {
-            value = data[columnOffset - 1]; // Just use the code
+        if ("".equals(option)) {
+            option = data[columnOffset - 1]; // Just use the code
         } else {
-            value = String.format("%s (%s)", value, data[columnOffset - 1]); // Append the code to the label
+            option = String.format("%s (%s)", option, data[columnOffset - 1]); // Append the code to the label
         }
 
-        groupValues.add(value);
+        dimensionOptions.put(dimension, option);
         columnOffset += labelOffset;
 
         // add all other dimensions
         for (int i = columnOffset; i < data.length; i += labelOffset) {
 
-            value = data[i];
+            dimension = header[i];
+            option = data[i];
 
-            if ("".equals(value))
-                value = data[i - 1]; // Just use the code
+            if ("".equals(option))
+                option = data[i - 1]; // Just use the code
 
-            groupValues.add(value);
+            dimensionOptions.put(dimension, option);
         }
     }
 
@@ -62,7 +64,7 @@ public class Group implements Comparable<Group> {
 
     String getTitle() {
         StringBuffer buffer = new StringBuffer();
-        groupValues.forEach(v -> buffer.append(v).append("\n"));
+        dimensionOptions.values().forEach(v -> buffer.append(v).append("\n"));
         final int size = buffer.toString().length();
         return buffer.toString().substring(0, size - 1);
     }
@@ -73,7 +75,7 @@ public class Group implements Comparable<Group> {
 
     @Override
     public int hashCode() {
-        return groupValues.hashCode();
+        return dimensionOptions.hashCode();
     }
 
     @Override
@@ -81,20 +83,22 @@ public class Group implements Comparable<Group> {
         return this.hashCode() == object.hashCode();
     }
 
-
     @Override
     public int compareTo(Group o) {
 
         int compared = 0;
 
         // if the group arrays differ in length do not try and compare.
-        if (this.groupValues.size() != o.groupValues.size())
+        List<String> values = new ArrayList<>(this.dimensionOptions.values());
+        List<String> oValues = new ArrayList<>(o.dimensionOptions.values());
+
+        if (values.size() != o.dimensionOptions.values().size())
             return 0;
 
         // Order by each group value in turn
-        for (int i = 0; i < groupValues.size(); ++i) {
+        for (int i = 0; i < dimensionOptions.values().size(); ++i) {
 
-            compared = this.groupValues.get(i).compareTo(o.groupValues.get(i));
+            compared = values.get(i).compareTo(oValues.get(i));
 
             // return if we can determine order from this dimension option
             if (compared != 0)

--- a/src/test/java/dp/xlsx/DatasetFormatterTest.java
+++ b/src/test/java/dp/xlsx/DatasetFormatterTest.java
@@ -81,8 +81,8 @@ public class DatasetFormatterTest {
         // When format is called
         datasetFormatter.format(sheet, file, datasetMetadata, style, style, style, style, style);
 
-        assertThat(sheet.getRow(metadataRows + 0).getCell(1).getStringCellValue()).isEqualTo("England (K02000003)\nBBB");
-        assertThat(sheet.getRow(metadataRows + 0).getCell(2).getStringCellValue()).isEqualTo("Wales (K02000002)\nAAA");
+        assertThat(sheet.getRow(metadataRows + 0).getCell(1).getStringCellValue()).isEqualTo("AAA\nWales (K02000002)");
+        assertThat(sheet.getRow(metadataRows + 0).getCell(2).getStringCellValue()).isEqualTo("BBB\nEngland (K02000003)");
     }
 
     @Test

--- a/src/test/java/dp/xlsx/GroupTest.java
+++ b/src/test/java/dp/xlsx/GroupTest.java
@@ -5,12 +5,14 @@ import org.junit.Test;
 
 public class GroupTest {
 
+    private final String[] headers = new String[]{"V4_0", "Time_codelist", "Time", "Geography_codelist", "Geography", "cpi1dim1aggid", "Aggregate"};
+    
     @Test
     public void testGroupCompare_ordersByGroupValuesAlphabetally_unsortedValues() throws Exception {
 
         // Given two groups, the first group alphabetically ordered after the second (BBB vs AAA)
-        Group group1 = new Group(new String[]{"86.8", "Month", "Jan-96", "K02000001", "BBB", "cpi1dim1A0", "CPI (overall index)"}, 1);
-        Group group2 = new Group(new String[]{"86.8", "Month", "Jan-96", "K02000001", "AAA", "cpi1dim1A0", "CPI (overall index)"}, 1);
+        Group group1 = new Group(new String[]{"86.8", "Month", "Jan-96", "K02000001", "BBB", "cpi1dim1A0", "CPI (overall index)"}, headers, 1);
+        Group group2 = new Group(new String[]{"86.8", "Month", "Jan-96", "K02000001", "AAA", "cpi1dim1A0", "CPI (overall index)"}, headers, 1);
 
         // When compareTo is called
         int compared = group1.compareTo(group2);
@@ -20,11 +22,24 @@ public class GroupTest {
     }
 
     @Test
+    public void testGroup_getTitle_OrdersByDimensionNameAlphabetically() throws Exception {
+
+        // Given a group
+        Group group = new Group(new String[]{"86.8", "Month", "Jan-96", "K02000001", "UK", "cpi1dim1A0", "CPI (overall index)"}, headers, 1);
+
+        // When getTitle is called
+        String title = group.getTitle();
+
+        // Then the value contains the option names ordered alphabetically by their dimension name
+        Assertions.assertThat(title).isEqualTo("CPI (overall index)\nUK (K02000001)");
+    }
+
+    @Test
     public void testGroupCompare_ordersByGroupValuesAlphabetally_sortedValues() throws Exception {
 
         // Given two groups, the first group alphabetically ordered before the second (AAA vs BBB)
-        Group group1 = new Group(new String[]{"86.8", "Month", "Jan-96", "K02000001", "AAA", "cpi1dim1A0", "CPI (overall index)"}, 1);
-        Group group2 = new Group(new String[]{"86.8", "Month", "Jan-96", "K02000001", "BBB", "cpi1dim1A0", "CPI (overall index)"}, 1);
+        Group group1 = new Group(new String[]{"86.8", "Month", "Jan-96", "K02000001", "AAA", "cpi1dim1A0", "CPI (overall index)"}, headers, 1);
+        Group group2 = new Group(new String[]{"86.8", "Month", "Jan-96", "K02000001", "BBB", "cpi1dim1A0", "CPI (overall index)"}, headers, 1);
 
         // When compareTo is called
         int compared = group1.compareTo(group2);
@@ -37,8 +52,8 @@ public class GroupTest {
     public void testGroupCompare_ordersByGroupValuesAlphabetally_unsortedSecondaryValues() throws Exception {
 
         // Given two groups, the first group alphabetically ordered after the second (DDD vs CCC)
-        Group group1 = new Group(new String[]{"86.8", "Month", "Jan-96", "K02000001", "AAA", "cpi1dim1A0", "DDD"}, 1);
-        Group group2 = new Group(new String[]{"86.8", "Month", "Jan-96", "K02000001", "AAA", "cpi1dim1A0", "CCC"}, 1);
+        Group group1 = new Group(new String[]{"86.8", "Month", "Jan-96", "K02000001", "AAA", "cpi1dim1A0", "DDD"}, headers, 1);
+        Group group2 = new Group(new String[]{"86.8", "Month", "Jan-96", "K02000001", "AAA", "cpi1dim1A0", "CCC"}, headers, 1);
 
         // When compareTo is called
         int compared = group1.compareTo(group2);
@@ -51,8 +66,8 @@ public class GroupTest {
     public void testGroupCompare_ordersByGroupValuesAlphabetally_sortedSecondaryValues() throws Exception {
 
         // Given two groups, the first group alphabetically ordered before the second (DDD vs CCC)
-        Group group1 = new Group(new String[]{"86.8", "Month", "Jan-96", "K02000001", "AAA", "cpi1dim1A0", "CCC"}, 1);
-        Group group2 = new Group(new String[]{"86.8", "Month", "Jan-96", "K02000001", "AAA", "cpi1dim1A0", "DDD"}, 1);
+        Group group1 = new Group(new String[]{"86.8", "Month", "Jan-96", "K02000001", "AAA", "cpi1dim1A0", "CCC"}, headers, 1);
+        Group group2 = new Group(new String[]{"86.8", "Month", "Jan-96", "K02000001", "AAA", "cpi1dim1A0", "DDD"}, headers, 1);
 
         // When compareTo is called
         int compared = group1.compareTo(group2);
@@ -62,11 +77,25 @@ public class GroupTest {
     }
 
     @Test
+    public void testGroupEquals() throws Exception {
+
+        // Given two groups, the first group alphabetically ordered before the second (DDD vs CCC)
+        Group group1 = new Group(new String[]{"86.8", "Month", "Jan-96", "K02000001", "AAA", "cpi1dim1A0", "CCC"}, headers, 1);
+        Group group2 = new Group(new String[]{"86.8", "Month", "Jan-96", "K02000001", "AAA", "cpi1dim1A0", "CCC"}, headers, 1);
+
+        // When compareTo is called
+        boolean equals = group1.equals(group2);
+
+        // Then the first group is considered to be ordered before the second
+        Assertions.assertThat(equals).isTrue();
+    }
+
+    @Test
     public void testGroupCompare_ordersByGroupValuesAlphabetally_equalValues() throws Exception {
 
         // Given two groups with the same values
-        Group group1 = new Group(new String[]{"86.8", "Month", "Jan-96", "K02000001", "AAA", "cpi1dim1A0", "CPI (overall index)"}, 1);
-        Group group2 = new Group(new String[]{"86.8", "Month", "Jan-96", "K02000001", "AAA", "cpi1dim1A0", "CPI (overall index)"}, 1);
+        Group group1 = new Group(new String[]{"86.8", "Month", "Jan-96", "K02000001", "AAA", "cpi1dim1A0", "CPI (overall index)"}, headers, 1);
+        Group group2 = new Group(new String[]{"86.8", "Month", "Jan-96", "K02000001", "AAA", "cpi1dim1A0", "CPI (overall index)"}, headers, 1);
 
         // When compareTo is called
         int compared = group1.compareTo(group2);

--- a/src/test/java/dp/xlsx/V4FileTest.java
+++ b/src/test/java/dp/xlsx/V4FileTest.java
@@ -25,8 +25,8 @@ public class V4FileTest {
         try (final InputStream stream = V4FileTest.class.getResourceAsStream("v4_0.csv")) {
             final V4File file = new V4File(stream);
             final Group group = file.groupData().get(0);
-            assertThat(group.getObservation("Jan-96")).isEqualTo("86.8");
-            assertThat(group.getObservation("Feb-96")).isEqualTo("86.9");
+            assertThat(group.getObservation("Jan-96")).isEqualTo("93.8");
+            assertThat(group.getObservation("Feb-96")).isEqualTo("93.9");
         }
     }
 
@@ -35,17 +35,29 @@ public class V4FileTest {
         try (final InputStream stream = V4FileTest.class.getResourceAsStream("v4_0.csv")) {
             final V4File file = new V4File(stream);
             final Group group = file.groupData().get(0);
-            assertThat(group.getTitle()).isEqualTo("K02000001\n" + "CPI (overall index)");
+            assertThat(group.getTitle()).isEqualTo("01.2 Non-alcoholic beverages\nK02000001");
         }
     }
 
     @Test
-    public void timeTitles() throws IOException {
-        try (final InputStream stream = V4FileTest.class.getResourceAsStream("v4_0.csv")) {
-            final V4File file = new V4File(stream);
-            final Group group = file.groupData().get(0);
-            assertThat(group.getTitle()).isEqualTo("K02000001\n" + "CPI (overall index)");
-        }
+    public void orderedDimensionTitle() throws IOException {
+
+        // Given v4 data.
+        String csvHeader = "V4_0,Time_codelist,Time,Geography_codelist,Geography,cpi1dim1aggid,Aggregate\n";
+        String csvRow1 = "88,Month,Oct-00,K02000001,,cpi1dim1A0,CPI (overall index)\n";
+        String csvRow2 = "88,Month,Jan-96,K02000001,,cpi1dim1A0,CPI (overall index)\n";
+        String csvRow3 = "88,Month,Apr-17,K02000001,,cpi1dim1A0,CPI (overall index)\n";
+        String csvContent = csvHeader + csvRow1 + csvRow2 + csvRow3;
+
+        InputStream inputStream = new ByteArrayInputStream(csvContent.getBytes());
+        final V4File file = new V4File(inputStream);
+        file.groupData();
+
+        // When getDimensionsTitle is called.
+        String dimensionsTitle = file.getDimensionsTitle();
+
+        // Then the dimensions are returned in alphabetical order
+        assertThat(dimensionsTitle).isEqualTo("Aggregate\nGeography");
     }
 
     @Test


### PR DESCRIPTION
### What

The previous implementation of the dataset formatter was using dimension titles from the metadata endpoint on the dataset API. This returned the dimensions in the order specified by the recipe API. The dimension option headers are ordered as they are in the original V4 file. If the order differs between the V4 file and the recipe then the order would differ between the dimension names and options in the XLSX. 

It was decided that dimensions / options should be ordered alphabetically by dimension name. This way we do not rely on the order of other processes but ensure a consistent order when producing the XLSX.

### How to review

Review changes + test

### Who can review

Anyone
