### PR TITLE
Order dimension headers alphabetically in the XLSX

### DIFF
--- a/src/main/java/dp/xlsx/Group.java
+++ b/src/main/java/dp/xlsx/Group.java
@@ -8,7 +8,7 @@ import java.util.Map;
 /**
  * A single unique combination of dimension options, and its associated observations.
  */
-public class Group implements Comparable<Group> {
+public class Group {
 
     private List<String> groupValues; // the unique dimension options
     private Map<String, String> observations; // time: observation
@@ -35,7 +35,7 @@ public class Group implements Comparable<Group> {
             value = String.format("%s (%s)", value, data[columnOffset - 1]); // Append the code to the label
         }
 
-        groupValues.add(value);
+        getGroupValues().add(value);
         columnOffset += labelOffset;
 
         // add all other dimensions
@@ -46,7 +46,7 @@ public class Group implements Comparable<Group> {
             if ("".equals(value))
                 value = data[i - 1]; // Just use the code
 
-            groupValues.add(value);
+            getGroupValues().add(value);
         }
     }
 
@@ -60,20 +60,13 @@ public class Group implements Comparable<Group> {
         observations.put(timeLabel, observation);
     }
 
-    String getTitle() {
-        StringBuffer buffer = new StringBuffer();
-        groupValues.forEach(v -> buffer.append(v).append("\n"));
-        final int size = buffer.toString().length();
-        return buffer.toString().substring(0, size - 1);
-    }
-
     String getObservation(String time) {
         return observations.get(time);
     }
 
     @Override
     public int hashCode() {
-        return groupValues.hashCode();
+        return getGroupValues().hashCode();
     }
 
     @Override
@@ -81,26 +74,7 @@ public class Group implements Comparable<Group> {
         return this.hashCode() == object.hashCode();
     }
 
-
-    @Override
-    public int compareTo(Group o) {
-
-        int compared = 0;
-
-        // if the group arrays differ in length do not try and compare.
-        if (this.groupValues.size() != o.groupValues.size())
-            return 0;
-
-        // Order by each group value in turn
-        for (int i = 0; i < groupValues.size(); ++i) {
-
-            compared = this.groupValues.get(i).compareTo(o.groupValues.get(i));
-
-            // return if we can determine order from this dimension option
-            if (compared != 0)
-                return compared;
-        }
-
-        return compared;
+    protected List<String> getGroupValues() {
+        return this.groupValues;
     }
 }

--- a/src/main/java/dp/xlsx/SortedGroup.java
+++ b/src/main/java/dp/xlsx/SortedGroup.java
@@ -1,0 +1,69 @@
+package dp.xlsx;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+class SortedGroup implements Comparable<SortedGroup> {
+
+    private final Group group;
+    private final List<String> groupValues; // the unique dimension options
+
+    /**
+     * Groups are by default ordered by the original order in the v4 file.
+     *
+     * @param group           - the original group that needs sorting
+     * @param positionMapping - a map with the original position of the header and the ordered position it should be
+     *                        when sorted.
+     */
+    SortedGroup(Group group, Map<Integer, Integer> positionMapping) {
+        this.group = group;
+
+        // apply position mappings to the group values
+
+        List<String> unsortedGroupValues = group.getGroupValues();
+        groupValues = new ArrayList<>(unsortedGroupValues);
+
+        for (int i = 0; i < unsortedGroupValues.size(); ++i) {
+
+            int sortedPosition = positionMapping.get(i);
+            groupValues.set(sortedPosition, unsortedGroupValues.get(i));
+        }
+    }
+
+    String getTitle() {
+        return getGroupValues().stream()
+                .collect(Collectors.joining("\n"));
+    }
+
+    String getObservation(String time) {
+        return this.group.getObservation(time);
+    }
+
+    @Override
+    public int compareTo(SortedGroup o) {
+
+        int compared = 0;
+
+        // if the group arrays differ in length do not try and compare.
+        if (getGroupValues().size() != o.getGroupValues().size())
+            return 0;
+
+        // Order by each group value in turn
+        for (int i = 0; i < getGroupValues().size(); ++i) {
+
+            compared = getGroupValues().get(i).compareTo(o.getGroupValues().get(i));
+
+            // return if we can determine order from this dimension option
+            if (compared != 0)
+                return compared;
+        }
+
+        return compared;
+    }
+
+    List<String> getGroupValues() {
+        return groupValues;
+    }
+}

--- a/src/main/java/dp/xlsx/V4File.java
+++ b/src/main/java/dp/xlsx/V4File.java
@@ -9,8 +9,18 @@ import java.io.InputStreamReader;
 import java.text.DateFormat;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Iterator;
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.TreeMap;
+import java.util.TreeSet;
 
 /**
  * A class used to extract information from a V4 file.
@@ -18,8 +28,8 @@ import java.util.List;
 class V4File {
 
     private final List<String[]> data; // v4 CSV rows
-
     private final int headerOffset;
+    private final String[] header;
 
     private Set<String> uniqueTimeValues;
 
@@ -28,7 +38,8 @@ class V4File {
         try (final CSVReader reader = new CSVReader(new InputStreamReader(inputStream))) {
             data = reader.readAll();
         }
-        final String[] header = data.get(0);
+
+        header = data.get(0);
         final String v4Code = header[0];
         headerOffset = Integer.parseInt(v4Code.split("V4_")[1]) + 1;
         uniqueTimeValues = new HashSet<>();
@@ -66,6 +77,58 @@ class V4File {
         return new ArrayList<>(groups.values());
     }
 
+    /**
+     * Return the list of dimensions that will be displayed along the columns of the XLSX output.
+     * (not including the time dimension or whichever other dimension is not shown along the rows.)
+     * @return
+     */
+    List<String> getDimensions() {
+
+        int offset = headerOffset + 3; // skip the observation, time code and time label
+        final int labelOffset = 2; // Skip the code and get the label when iterating columns
+        List<String> dimensions = new ArrayList<>();
+
+        for (int i = offset; i < header.length; i += labelOffset) {
+            dimensions.add(header[i]);
+        }
+
+        return dimensions;
+    }
+
+    /**
+     * Return a map containing the original position of the dimensions mapped to their sorted position.
+     * This is done once to save having to sort each heading of the XLSX columns by dimension names.
+     * By calculating the mapping once we can app
+     */
+    public Map<Integer, Integer> getSortedPositionMapping() {
+
+        List<String> dimensions = getDimensions();
+        Set<String> sortedDimensions = new TreeSet<>();
+
+        Map<Integer, Integer> positionMappings = new HashMap<>();
+
+        // populate a sorted set of dimensions.
+        for (String dimension : dimensions) {
+            sortedDimensions.add(dimension);
+        }
+
+        // determine where the new position of each dimension is after sorting.
+        for (int i = 0; i < dimensions.size(); ++i) {
+
+            int j = 0;
+            Iterator<String> iterator = sortedDimensions.iterator();
+
+            while (iterator.hasNext()) {
+                if (iterator.next().equals(dimensions.get(i))) {
+                    positionMappings.put(i, j);
+                    break;
+                }
+                j++;
+            }
+        }
+
+        return positionMappings;
+    }
 
     /**
      * Get all unique time labels found in the v4 file
@@ -79,6 +142,7 @@ class V4File {
     /**
      * Return the time labels in chronological order if the format is recognised, else
      * returns the labels in alphabetical order.
+     *
      * @return
      */
     Collection<String> getOrderedTimeLabels() {
@@ -94,7 +158,7 @@ class V4File {
         }
 
         DateFormat dateFormat = new SimpleDateFormat(format);
-        Map<Date,String> dates = new TreeMap<>();
+        Map<Date, String> dates = new TreeMap<>();
 
         for (String timeValue : uniqueTimeValues) {
             Date date;

--- a/src/test/java/dp/xlsx/DatasetFormatterTest.java
+++ b/src/test/java/dp/xlsx/DatasetFormatterTest.java
@@ -81,8 +81,8 @@ public class DatasetFormatterTest {
         // When format is called
         datasetFormatter.format(sheet, file, datasetMetadata, style, style, style, style, style);
 
-        assertThat(sheet.getRow(metadataRows + 0).getCell(1).getStringCellValue()).isEqualTo("England (K02000003)\nBBB");
-        assertThat(sheet.getRow(metadataRows + 0).getCell(2).getStringCellValue()).isEqualTo("Wales (K02000002)\nAAA");
+        assertThat(sheet.getRow(metadataRows + 0).getCell(1).getStringCellValue()).isEqualTo("AAA\nWales (K02000002)");
+        assertThat(sheet.getRow(metadataRows + 0).getCell(2).getStringCellValue()).isEqualTo("BBB\nEngland (K02000003)");
     }
 
     @Test

--- a/src/test/java/dp/xlsx/SortedGroupTest.java
+++ b/src/test/java/dp/xlsx/SortedGroupTest.java
@@ -3,17 +3,29 @@ package dp.xlsx;
 import org.assertj.core.api.Assertions;
 import org.junit.Test;
 
-public class GroupTest {
+import java.util.HashMap;
+import java.util.Map;
+
+public class SortedGroupTest {
+
+    private final Map<Integer, Integer> positionMapping = new HashMap() {{
+        put(0, 1);
+        put(1, 0);
+    }};
 
     @Test
     public void testGroupCompare_ordersByGroupValuesAlphabetally_unsortedValues() throws Exception {
+
 
         // Given two groups, the first group alphabetically ordered after the second (BBB vs AAA)
         Group group1 = new Group(new String[]{"86.8", "Month", "Jan-96", "K02000001", "BBB", "cpi1dim1A0", "CPI (overall index)"}, 1);
         Group group2 = new Group(new String[]{"86.8", "Month", "Jan-96", "K02000001", "AAA", "cpi1dim1A0", "CPI (overall index)"}, 1);
 
+        SortedGroup sortedGroup1 = new SortedGroup(group1, positionMapping);
+        SortedGroup sortedGroup2 = new SortedGroup(group2, positionMapping);
+
         // When compareTo is called
-        int compared = group1.compareTo(group2);
+        int compared = sortedGroup1.compareTo(sortedGroup2);
 
         // Then the first group is considered to be ordered after the second
         Assertions.assertThat(compared).isGreaterThan(0);
@@ -26,8 +38,11 @@ public class GroupTest {
         Group group1 = new Group(new String[]{"86.8", "Month", "Jan-96", "K02000001", "AAA", "cpi1dim1A0", "CPI (overall index)"}, 1);
         Group group2 = new Group(new String[]{"86.8", "Month", "Jan-96", "K02000001", "BBB", "cpi1dim1A0", "CPI (overall index)"}, 1);
 
+        SortedGroup sortedGroup1 = new SortedGroup(group1, positionMapping);
+        SortedGroup sortedGroup2 = new SortedGroup(group2, positionMapping);
+
         // When compareTo is called
-        int compared = group1.compareTo(group2);
+        int compared = sortedGroup1.compareTo(sortedGroup2);
 
         // Then the first group is considered to be ordered after the second
         Assertions.assertThat(compared).isLessThan(0);
@@ -40,8 +55,11 @@ public class GroupTest {
         Group group1 = new Group(new String[]{"86.8", "Month", "Jan-96", "K02000001", "AAA", "cpi1dim1A0", "DDD"}, 1);
         Group group2 = new Group(new String[]{"86.8", "Month", "Jan-96", "K02000001", "AAA", "cpi1dim1A0", "CCC"}, 1);
 
+        SortedGroup sortedGroup1 = new SortedGroup(group1, positionMapping);
+        SortedGroup sortedGroup2 = new SortedGroup(group2, positionMapping);
+
         // When compareTo is called
-        int compared = group1.compareTo(group2);
+        int compared = sortedGroup1.compareTo(sortedGroup2);
 
         // Then the first group is considered to be ordered after the second
         Assertions.assertThat(compared).isGreaterThan(0);
@@ -54,8 +72,11 @@ public class GroupTest {
         Group group1 = new Group(new String[]{"86.8", "Month", "Jan-96", "K02000001", "AAA", "cpi1dim1A0", "CCC"}, 1);
         Group group2 = new Group(new String[]{"86.8", "Month", "Jan-96", "K02000001", "AAA", "cpi1dim1A0", "DDD"}, 1);
 
+        SortedGroup sortedGroup1 = new SortedGroup(group1, positionMapping);
+        SortedGroup sortedGroup2 = new SortedGroup(group2, positionMapping);
+
         // When compareTo is called
-        int compared = group1.compareTo(group2);
+        int compared = sortedGroup1.compareTo(sortedGroup2);
 
         // Then the first group is considered to be ordered before the second
         Assertions.assertThat(compared).isLessThan(0);
@@ -68,8 +89,11 @@ public class GroupTest {
         Group group1 = new Group(new String[]{"86.8", "Month", "Jan-96", "K02000001", "AAA", "cpi1dim1A0", "CPI (overall index)"}, 1);
         Group group2 = new Group(new String[]{"86.8", "Month", "Jan-96", "K02000001", "AAA", "cpi1dim1A0", "CPI (overall index)"}, 1);
 
+        SortedGroup sortedGroup1 = new SortedGroup(group1, positionMapping);
+        SortedGroup sortedGroup2 = new SortedGroup(group2, positionMapping);
+
         // When compareTo is called
-        int compared = group1.compareTo(group2);
+        int compared = sortedGroup1.compareTo(sortedGroup2);
 
         // Then the groups are considered to have the same order
         Assertions.assertThat(compared).isEqualTo(0);

--- a/src/test/java/dp/xlsx/V4FileTest.java
+++ b/src/test/java/dp/xlsx/V4FileTest.java
@@ -7,6 +7,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -27,24 +28,6 @@ public class V4FileTest {
             final Group group = file.groupData().get(0);
             assertThat(group.getObservation("Jan-96")).isEqualTo("86.8");
             assertThat(group.getObservation("Feb-96")).isEqualTo("86.9");
-        }
-    }
-
-    @Test
-    public void groupTitles() throws IOException {
-        try (final InputStream stream = V4FileTest.class.getResourceAsStream("v4_0.csv")) {
-            final V4File file = new V4File(stream);
-            final Group group = file.groupData().get(0);
-            assertThat(group.getTitle()).isEqualTo("K02000001\n" + "CPI (overall index)");
-        }
-    }
-
-    @Test
-    public void timeTitles() throws IOException {
-        try (final InputStream stream = V4FileTest.class.getResourceAsStream("v4_0.csv")) {
-            final V4File file = new V4File(stream);
-            final Group group = file.groupData().get(0);
-            assertThat(group.getTitle()).isEqualTo("K02000001\n" + "CPI (overall index)");
         }
     }
 
@@ -92,5 +75,35 @@ public class V4FileTest {
         assertThat(labels.get(0)).isEqualTo("01-96");
         assertThat(labels.get(1)).isEqualTo("10-00");
         assertThat(labels.get(2)).isEqualTo("11-17");
+    }
+
+    @Test
+    public void getDimensions_ReturnsAllButFirstTimeDimension() throws Exception {
+
+        String csvHeader = "V4_0,Time_codelist,Time,Geography_codelist,Geography,cpi1dim1aggid,Aggregate\n";
+        String csvRow1 = "88,Month,10-00,K02000001,,cpi1dim1A0,CPI (overall index)\n";
+        String csvContent = csvHeader + csvRow1;
+
+        InputStream inputStream = new ByteArrayInputStream(csvContent.getBytes());
+        final V4File file = new V4File(inputStream);
+        List<String> dimensions = file.getDimensions();
+
+        assertThat(dimensions.get(0)).isEqualTo("Geography");
+        assertThat(dimensions.get(1)).isEqualTo("Aggregate");
+    }
+
+    @Test
+    public void getSortedPositionMapping() throws Exception {
+
+        String csvHeader = "V4_0,Time_codelist,Time,Geography_codelist,Geography,cpi1dim1aggid,Aggregate\n";
+        String csvRow1 = "88,Month,10-00,K02000001,,cpi1dim1A0,CPI (overall index)\n";
+        String csvContent = csvHeader + csvRow1;
+
+        InputStream inputStream = new ByteArrayInputStream(csvContent.getBytes());
+        final V4File file = new V4File(inputStream);
+        Map<Integer, Integer> sortedPositionMapping = file.getSortedPositionMapping();
+
+        assertThat(sortedPositionMapping.get(0)).isEqualTo(1);
+        assertThat(sortedPositionMapping.get(1)).isEqualTo(0);
     }
 }


### PR DESCRIPTION
### What

The previous implementation of the dataset formatter was using dimension titles from the metadata endpoint on the dataset API. This returned the dimensions in the order specified by the recipe API. The dimension option headers are ordered as they are in the original V4 file. If the order differs between the V4 file and the recipe then the order would differ between the dimension names and options in the XLSX. 

It was decided that dimensions / options should be ordered alphabetically by dimension name. This way we do not rely on the order of other processes but ensure a consistent order when producing the XLSX.

### How to review

Review changes + test

### Who can review

Anyone
