### PR TITLE
fixed incorrect metadata url and file name for filter jobs

### DIFF
--- a/src/main/java/dp/handler/Handler.java
+++ b/src/main/java/dp/handler/Handler.java
@@ -100,7 +100,7 @@ public class Handler {
         WorkbookDetails details = null;
 
         try {
-            metadataURL = new URL(filter.getLinks().getVersion().getHref());
+            metadataURL = new URL(filter.getLinks().getVersion().getHref() + "/metadata");
         } catch (MalformedURLException e) {
             throw new IOException(format("error while attempting to create metadata URL filterID {0}, value: {1}",
                     message.getFilterId().toString(), filter.getLinks().getVersion().getHref()), e);
@@ -114,7 +114,7 @@ public class Handler {
         }
 
         try {
-            details = createWorkbook(object, datasetMetadata, message.getFilename().toString());
+            details = createWorkbook(object, datasetMetadata, message.getFilterId().toString());
         } catch (IOException e) {
             throw new IOException(format("error while attempting to create XLSX workbook filterID: {0}, filename: {1}",
                     message.getFilterId().toString(), message.getFilename().toString()), e);
@@ -170,7 +170,8 @@ public class Handler {
         LOGGER.info("completed processing kafka message", message.getFilterId());
     }
 
-    private WorkbookDetails createWorkbook(S3Object object, Metadata datasetMetadata, String filename) throws IOException {
+    private WorkbookDetails createWorkbook(S3Object object, Metadata datasetMetadata, String filename)
+            throws IOException {
         try (final Workbook workbook = converter.toXLSX(object.getObjectContent(), datasetMetadata);
              final ByteArrayOutputStream outputStream = new ByteArrayOutputStream()) {
             workbook.write(outputStream);


### PR DESCRIPTION
Fix for defect where filtered downloads is not using the correct metadata url and not using the filterID as the file name.

### How to test
pull changes, create a filter download. The XLSX file should have a fully populated metadata tab and the filename should be `<FILTER_ID>.xlsx`