### PR TITLE
fix incorrect dataset metadata url

### DIFF
--- a/src/main/java/dp/api/dataset/DatasetAPIClient.java
+++ b/src/main/java/dp/api/dataset/DatasetAPIClient.java
@@ -15,15 +15,6 @@ public interface DatasetAPIClient {
     /**
      * Get the Dataset {@link Metadata}.
      *
-     * @param url the version url to get the metadata for.
-     * @return the Dataset {@link Metadata}.
-     * @throws MalformedURLException problem getting the metadata.
-     */
-    Metadata getMetadata(URL url) throws MalformedURLException, FilterAPIException;
-
-    /**
-     * Get the Dataset {@link Metadata}.
-     *
      * @param versionPath the version uri to get the metadata for.
      * @return the Dataset {@link Metadata}.
      * @throws MalformedURLException MalformedURLException problem getting the metadata.

--- a/src/main/java/dp/api/dataset/DatasetAPIClientImpl.java
+++ b/src/main/java/dp/api/dataset/DatasetAPIClientImpl.java
@@ -42,27 +42,27 @@ public class DatasetAPIClientImpl implements DatasetAPIClient {
     @Autowired
     private ObjectMapper objectMapper;
 
-    public Metadata getMetadata(URL url) throws FilterAPIException{
-        LOGGER.info("getting dataset version data from the dataset api, url : {}", url);
+    public Metadata getMetadata(final String versionPath) throws MalformedURLException, FilterAPIException {
+        URL metadataURL = new URL(datasetAPIURL + versionPath + "/metadata");
+
+        LOGGER.info("getting dataset version data from the dataset api, url : {}", metadataURL);
         try {
             HttpHeaders httpHeaders = new HttpHeaders();
             httpHeaders.add(AUTH_HEADER_KEY, token);
             HttpEntity entity = new HttpEntity<>(httpHeaders);
-            ResponseEntity<Metadata> responseEntity = restTemplate.exchange(url.toString(), HttpMethod.GET, entity, Metadata.class);
-            LOGGER.info("dataset api get response, url : {}, response {}", url, responseEntity.getStatusCode());
+            ResponseEntity<Metadata> responseEntity = restTemplate.exchange(metadataURL.toString(), HttpMethod.GET, entity, Metadata.class);
+            LOGGER.info("dataset api get response, url : {}, response {}", metadataURL.toString(),
+                    responseEntity.getStatusCode());
             return responseEntity.getBody();
 
         } catch (RestClientException e) {
-            throw new FilterAPIException(format("get dataset metadata returned an error, URL {0}", url.toString()), e);
+            throw new FilterAPIException(format("get dataset metadata returned an error, URL {0}", metadataURL.toString()), e);
         }
-    }
 
-    public Metadata getMetadata(final String versionPath) throws MalformedURLException, FilterAPIException {
-        return getMetadata(new URL(datasetAPIURL + versionPath + "/metadata"));
     }
 
     public void putVersionDownloads(final String datasetVersionURL, DownloadsList downloads) throws
-            MalformedURLException, FilterAPIException{
+            MalformedURLException, FilterAPIException {
         final String url = new URL(datasetAPIURL + datasetVersionURL).toString();
 
         try {

--- a/src/main/java/dp/handler/Handler.java
+++ b/src/main/java/dp/handler/Handler.java
@@ -95,12 +95,13 @@ public class Handler {
         LOGGER.info("handling filter message: ", message.getFilterId().toString());
 
         Filter filter = filterAPIClient.getFilter(message.getFilterId().toString());
-        URL metadataURL = null;
         Metadata datasetMetadata = null;
+        String metadataURL = null;
         WorkbookDetails details = null;
 
         try {
-            metadataURL = new URL(filter.getLinks().getVersion().getHref() + "/metadata");
+            URL url = new URL(filter.getLinks().getVersion().getHref());
+            metadataURL = url.getPath();
         } catch (MalformedURLException e) {
             throw new IOException(format("error while attempting to create metadata URL filterID {0}, value: {1}",
                     message.getFilterId().toString(), filter.getLinks().getVersion().getHref()), e);

--- a/src/test/java/dp/handler/HandlerTest.java
+++ b/src/test/java/dp/handler/HandlerTest.java
@@ -73,7 +73,7 @@ public class HandlerTest {
     private String edition = "2017";
     private String version = "1";
     private String filename = "morty";
-    private String metadataURL = "/datasets/456/editions/2017/versions/1";
+    private String versionURL = "/datasets/456/editions/2017/versions/1";
 
     @Test
     public void validExportFileFilterMessage() throws IOException {
@@ -99,7 +99,7 @@ public class HandlerTest {
 
         verify(s3Client, times(1)).getObject(anyString(), anyString());
         verify(filterAPI, times(1)).getFilter(exportedFile.getFilterId().toString());
-        verify(datasetAPI, times(1)).getMetadata(new URL(filter.getLinks().getVersion().getHref() + "/metadata"));
+        verify(datasetAPI, times(1)).getMetadata(versionURL);
         verify(converter, times(1)).toXLSX(any(), any());
 
         verify(s3Client, times(1)).putObject(any());
@@ -132,7 +132,7 @@ public class HandlerTest {
 
         verify(s3Client, times(1)).getObject(anyString(), anyString());
         verify(filterAPI, times(1)).getFilter(exportedFile.getFilterId().toString());
-        verify(datasetAPI, never()).getMetadata(any(URL.class));
+        verify(datasetAPI, never()).getMetadata(anyString());
         verify(converter, never()).toXLSX(any(), any());
         verify(s3Client, never()).putObject(any());
         verify(filterAPI, never()).addXLSXFile(any(), any(), anyLong());
@@ -142,7 +142,6 @@ public class HandlerTest {
     public void validFilterMessageGetMetadataError() throws Exception {
         S3Object s3Object = mock(S3Object.class);
         S3ObjectInputStream stream = mock(S3ObjectInputStream.class);
-        URL metadataURL = new URL("http://localhost:20000/filters/1/metadata");
 
         Filter filter = createFilter();
 
@@ -154,7 +153,7 @@ public class HandlerTest {
                 .thenReturn(new URL("https://amazon.com/sdfsdf"));
         when(filterAPI.getFilter(any()))
                 .thenReturn(filter);
-        when(datasetAPI.getMetadata(metadataURL))
+        when(datasetAPI.getMetadata(versionURL))
                 .thenThrow(new FilterAPIException("flubba wubba dub dub", null));
 
         final ExportedFile exportedFile = new ExportedFile("123", "s3://bucket/v4.csv", "", "", "", "", "");
@@ -162,7 +161,7 @@ public class HandlerTest {
         handler.listen(exportedFile);
         verify(s3Client, times(1)).getObject(anyString(), anyString());
         verify(filterAPI, times(1)).getFilter(exportedFile.getFilterId().toString());
-        verify(datasetAPI, times(1)).getMetadata(metadataURL);
+        verify(datasetAPI, times(1)).getMetadata(versionURL);
         verify(converter, never()).toXLSX(any(), any());
         verify(s3Client, never()).putObject(any());
         verify(filterAPI, never()).addXLSXFile(any(), any(), anyLong());
@@ -172,7 +171,6 @@ public class HandlerTest {
     public void validFilterConverterError() throws Exception {
         S3Object s3Object = mock(S3Object.class);
         S3ObjectInputStream stream = mock(S3ObjectInputStream.class);
-        URL metadataURL = new URL("http://localhost:20000/filters/1/metadata");
 
         Filter filter = createFilter();
         Metadata datasetMetadata = new Metadata();
@@ -185,7 +183,7 @@ public class HandlerTest {
                 .thenReturn(new URL("https://amazon.com/sdfsdf"));
         when(filterAPI.getFilter(any()))
                 .thenReturn(filter);
-        when(datasetAPI.getMetadata(metadataURL))
+        when(datasetAPI.getMetadata(versionURL))
                 .thenReturn(datasetMetadata);
         when(converter.toXLSX(any(), eq(datasetMetadata)))
                 .thenThrow(new IOException());
@@ -196,7 +194,7 @@ public class HandlerTest {
 
         verify(s3Client, times(1)).getObject(anyString(), anyString());
         verify(filterAPI, times(1)).getFilter(exportedFile.getFilterId().toString());
-        verify(datasetAPI, times(1)).getMetadata(metadataURL);
+        verify(datasetAPI, times(1)).getMetadata(versionURL);
         verify(converter, times(1)).toXLSX(any(), eq(datasetMetadata));
         verify(filterAPI, never()).addXLSXFile(any(), any(), anyLong());
         verify(s3Client, never()).putObject(any());
@@ -206,7 +204,6 @@ public class HandlerTest {
     public void validFilterMessageS3PutError() throws Exception {
         S3Object s3Object = mock(S3Object.class);
         S3ObjectInputStream stream = mock(S3ObjectInputStream.class);
-        URL metadataURL = new URL("http://localhost:20000/filters/1/metadata");
         Workbook workbookMock = mock(Workbook.class);
         SdkClientException ex = mock(SdkClientException.class);
         ArgumentCaptor<PutObjectRequest> arguments = ArgumentCaptor.forClass(PutObjectRequest.class);
@@ -222,7 +219,7 @@ public class HandlerTest {
                 .thenReturn(new URL("https://amazon.com/sdfsdf"));
         when(filterAPI.getFilter(any()))
                 .thenReturn(filter);
-        when(datasetAPI.getMetadata(metadataURL))
+        when(datasetAPI.getMetadata(versionURL))
                 .thenReturn(datasetMetadata);
         when(converter.toXLSX(any(), eq(datasetMetadata)))
                 .thenReturn(workbookMock);
@@ -235,7 +232,7 @@ public class HandlerTest {
 
         verify(s3Client, times(1)).getObject(anyString(), anyString());
         verify(filterAPI, times(1)).getFilter(exportedFile.getFilterId().toString());
-        verify(datasetAPI, times(1)).getMetadata(metadataURL);
+        verify(datasetAPI, times(1)).getMetadata(versionURL);
         verify(converter, times(1)).toXLSX(any(), eq(datasetMetadata));
         verify(s3Client, times(1)).putObject(arguments.capture());
         verify(filterAPI, never()).addXLSXFile(any(), any(), anyLong());
@@ -248,7 +245,6 @@ public class HandlerTest {
     public void validFilterMessageFilterAPIAddXLSFileError() throws Exception {
         S3Object s3Object = mock(S3Object.class);
         S3ObjectInputStream stream = mock(S3ObjectInputStream.class);
-        URL metadataURL = new URL("http://localhost:20000/filters/1/metadata");
         Workbook workbookMock = mock(Workbook.class);
         JsonProcessingException ex = mock(JsonProcessingException.class);
         ArgumentCaptor<PutObjectRequest> arguments = ArgumentCaptor.forClass(PutObjectRequest.class);
@@ -264,7 +260,7 @@ public class HandlerTest {
                 .thenReturn(new URL("https://amazon.com/sdfsdf"));
         when(filterAPI.getFilter(any()))
                 .thenReturn(filter);
-        when(datasetAPI.getMetadata(metadataURL))
+        when(datasetAPI.getMetadata(versionURL))
                 .thenReturn(datasetMetadata);
         when(converter.toXLSX(any(), eq(datasetMetadata)))
                 .thenReturn(workbookMock);
@@ -279,7 +275,7 @@ public class HandlerTest {
 
         verify(s3Client, times(1)).getObject(anyString(), anyString());
         verify(filterAPI, times(1)).getFilter(exportedFile.getFilterId().toString());
-        verify(datasetAPI, times(1)).getMetadata(metadataURL);
+        verify(datasetAPI, times(1)).getMetadata(versionURL);
         verify(converter, times(1)).toXLSX(any(), eq(datasetMetadata));
         verify(s3Client, times(1)).putObject(arguments.capture());
         verify(filterAPI, times(1)).addXLSXFile(any(), any(), anyLong());
@@ -298,7 +294,6 @@ public class HandlerTest {
         DownloadsList downloads = new DownloadsList(new Download("https://amazon.com/morty.xlsx", "0"), null);
         ArgumentCaptor<PutObjectRequest> arguments = ArgumentCaptor.forClass(PutObjectRequest.class);
 
-
         Metadata datasetMetadata = new Metadata();
 
         when(s3Object.getObjectContent())
@@ -307,7 +302,7 @@ public class HandlerTest {
                 .thenReturn(s3Object);
         when(s3Client.getUrl(anyString(), anyString()))
                 .thenReturn(new URL("https://amazon.com/morty.xlsx"));
-        when(datasetAPI.getMetadata(metadataURL))
+        when(datasetAPI.getMetadata(versionURL))
                 .thenReturn(datasetMetadata);
         when(converter.toXLSX(any(), any()))
                 .thenReturn(workBookMock);
@@ -317,9 +312,9 @@ public class HandlerTest {
 
         handler.listen(exportedFile);
 
-        verify(datasetAPI, times(1)).getMetadata(metadataURL);
+        verify(datasetAPI, times(1)).getMetadata(versionURL);
         verify(converter, times(1)).toXLSX(any(), any());
-        verify(datasetAPI, times(1)).putVersionDownloads(metadataURL, downloads);
+        verify(datasetAPI, times(1)).putVersionDownloads(versionURL, downloads);
         verify(workBookMock, times(1)).write(any(OutputStream.class));
         verify(s3Client, times(1)).putObject(arguments.capture());
 
@@ -338,7 +333,7 @@ public class HandlerTest {
         handler.listen(exportedFile);
 
         verify(s3Client, times(1)).getObject("bucket", "v4.csv");
-        verify(datasetAPI, never()).getMetadata(metadataURL);
+        verify(datasetAPI, never()).getMetadata(versionURL);
         verify(converter, never()).toXLSX(any(), any());
         verify(datasetAPI, never()).putVersionDownloads(any(), any());
         verify(s3Client, never()).putObject(any());
@@ -359,7 +354,7 @@ public class HandlerTest {
         handler.listen(exportedFile);
 
         verify(s3Client, times(1)).getObject("bucket", "v4.csv");
-        verify(datasetAPI, times(1)).getMetadata(metadataURL);
+        verify(datasetAPI, times(1)).getMetadata(versionURL);
         verify(converter, never()).toXLSX(any(), any());
         verify(datasetAPI, never()).putVersionDownloads(any(), any());
         verify(s3Client, never()).putObject(any());
@@ -373,7 +368,7 @@ public class HandlerTest {
 
         when(s3Client.getObject("bucket", "v4.csv"))
                 .thenReturn(s3Object);
-        when(datasetAPI.getMetadata(anyString()))
+        when(datasetAPI.getMetadata(versionURL))
                 .thenReturn(metadata);
         when(s3Object.getObjectContent())
                 .thenReturn(stream);
@@ -387,7 +382,7 @@ public class HandlerTest {
 
         verify(s3Client, times(1)).getObject("bucket", "v4.csv");
         verify(s3Object, times(1)).getObjectContent();
-        verify(datasetAPI, times(1)).getMetadata(metadataURL);
+        verify(datasetAPI, times(1)).getMetadata(versionURL);
         verify(converter, times(1)).toXLSX(stream, metadata);
         verify(datasetAPI, never()).putVersionDownloads(any(), any());
         verify(s3Client, never()).putObject(any());
@@ -409,12 +404,12 @@ public class HandlerTest {
                 .thenReturn(s3Object);
         when(s3Client.getUrl(anyString(), anyString()))
                 .thenReturn(new URL("https://amazon.com/morty.xlsx"));
-        when(datasetAPI.getMetadata(metadataURL))
+        when(datasetAPI.getMetadata(versionURL))
                 .thenReturn(metadata);
         when(converter.toXLSX(any(), any()))
                 .thenReturn(workbookMock);
-        doThrow(new FilterAPIException("flubba wubba dub dub", null)).when(datasetAPI)
-                .putVersionDownloads(any(), any());
+        doThrow(new FilterAPIException("flubba wubba dub dub", null))
+                .when(datasetAPI).putVersionDownloads(eq(versionURL), any());
 
         final ExportedFile exportedFile = new ExportedFile("", "s3://bucket/v4.csv", instanceID, datasetID, edition,
                 version, filename);
@@ -423,9 +418,9 @@ public class HandlerTest {
 
         verify(s3Client, times(1)).getObject("bucket", "v4.csv");
         verify(s3Object, times(1)).getObjectContent();
-        verify(datasetAPI, times(1)).getMetadata(metadataURL);
+        verify(datasetAPI, times(1)).getMetadata(versionURL);
         verify(converter, times(1)).toXLSX(stream, metadata);
-        verify(datasetAPI, times(1)).putVersionDownloads(any(), any());
+        verify(datasetAPI, times(1)).putVersionDownloads(eq(versionURL), any());
         verify(s3Client, times(1)).putObject(arguments.capture());
         verify(workbookMock, times(1)).close();
 
@@ -447,10 +442,11 @@ public class HandlerTest {
         when(filterAPI.getFilter(any())).thenReturn(filter);
 
         Metadata datasetMetadata = new Metadata();
-        when(datasetAPI.getMetadata(filter.getLinks().getVersion().getHref())).thenReturn(datasetMetadata);
 
-        when(converter.toXLSX(any(), any())).thenReturn(workbookMock);
-
+        when(datasetAPI.getMetadata(versionURL))
+                .thenReturn(datasetMetadata);
+        when(converter.toXLSX(any(), any()))
+                .thenReturn(workbookMock);
         when(s3Client.putObject(any()))
                 .thenThrow(new RuntimeException());
 
@@ -461,7 +457,7 @@ public class HandlerTest {
         } catch (Exception e) {
             verify(s3Client, times(1)).getObject(anyString(), anyString());
             verify(filterAPI, times(1)).getFilter(exportedFile.getFilterId().toString());
-            verify(datasetAPI, times(1)).getMetadata(filter.getLinks().getVersion().getHref());
+            verify(datasetAPI, times(1)).getMetadata(versionURL);
             verify(converter, times(1)).toXLSX(any(), any());
             verify(s3Client, times(1)).putObject(arguments.capture());
             verify(workbookMock, times(1)).dispose();
@@ -476,7 +472,7 @@ public class HandlerTest {
         Filter filter = new Filter();
         FilterLinks filterLinks = new FilterLinks();
         Link versionLink = new Link();
-        String versionHref = "http://localhost:20000/filters/1";
+        String versionHref = "http://localhost:22000/datasets/456/editions/2017/versions/1";
         versionLink.setHref(versionHref);
         versionLink.setId("666");
         filterLinks.setVersion(versionLink);


### PR DESCRIPTION
Fix incorrect dataset metadata URL's - should now always use configured dataset API host.
