### PR TITLE
Use new heap_mem variable for JVM args in nomad plan

### DIFF
--- a/dp-dataset-exporter-xlsx.nomad
+++ b/dp-dataset-exporter-xlsx.nomad
@@ -28,7 +28,7 @@ job "dp-dataset-exporter-xlsx" {
 
         args = [
           "java",
-          "-Xmx{{PUBLISHING_RESOURCE_MEM}}m",
+          "-Xmx{{PUBLISHING_RESOURCE_HEAP_MEM}}m",
           "-jar",
           "dp-dataset-exporter-xlsx.jar",
         ]


### PR DESCRIPTION
### What

Use new heap_mem variable for JVM args in nomad plan to prevent app being killed requesting too much memory

### How to review

Check for typos

### Who can review

Anyone