### PR TITLE
Optimise memory usage when reading V4 files.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -50,9 +50,10 @@
             <version>3.17</version>
         </dependency>
         <dependency>
-            <groupId>net.sf.opencsv</groupId>
-            <artifactId>opencsv</artifactId>
-            <version>2.3</version>
+            <groupId>com.univocity</groupId>
+            <artifactId>univocity-parsers</artifactId>
+            <version>2.5.9</version>
+            <type>jar</type>
         </dependency>
         <dependency>
             <groupId>org.apache.avro</groupId>

--- a/src/main/java/dp/xlsx/DatasetFormatter.java
+++ b/src/main/java/dp/xlsx/DatasetFormatter.java
@@ -56,7 +56,7 @@ class DatasetFormatter {
 
     void format() {
 
-        final List<Group> groups = file.groupData();
+        final Collection<Group> groups = file.groupData();
         final Collection<String> timeLabels = file.getOrderedTimeLabels();
 
         List<Group> sortedGroups = groups.stream().sorted().collect(Collectors.toList());

--- a/src/main/java/dp/xlsx/V4File.java
+++ b/src/main/java/dp/xlsx/V4File.java
@@ -51,6 +51,11 @@ class V4File {
             if ((line = bufferedReader.readLine()) != null) {
 
                 final String[] header = parser.parseLine(line);
+                if (header == null || header.length == 0) {
+                    throw new IOException("header row does not contain any content");
+                }
+
+
                 final String v4Code = header[0];
 
                 headerOffset = Integer.parseInt(v4Code.split("V4_")[1]) + 1;
@@ -60,6 +65,9 @@ class V4File {
             while ((line = bufferedReader.readLine()) != null) {
 
                 final String[] row = parser.parseLine(line);
+                if (row == null || row.length == 0) {
+                    continue;
+                }
 
                 final Group group = new Group(row, headerOffset);
                 final String timeValue = row[headerOffset + 1];

--- a/src/test/java/dp/xlsx/DatasetFormatterTest.java
+++ b/src/test/java/dp/xlsx/DatasetFormatterTest.java
@@ -9,7 +9,6 @@ import org.apache.poi.ss.usermodel.Sheet;
 import org.apache.poi.ss.usermodel.Workbook;
 import org.apache.poi.xssf.usermodel.XSSFWorkbook;
 import org.junit.Test;
-import org.mockito.Mock;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;

--- a/src/test/java/dp/xlsx/V4FileTest.java
+++ b/src/test/java/dp/xlsx/V4FileTest.java
@@ -7,7 +7,6 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Map;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -22,12 +21,49 @@ public class V4FileTest {
         }
     }
 
+    @Test(expected = IOException.class)
+    public void v4File_InvalidHeader() throws IOException {
+
+        // Given v4 data with an invalid header
+        String csvHeader = "\n";
+        String csvContent = csvHeader;
+
+        InputStream inputStream = new ByteArrayInputStream(csvContent.getBytes());
+
+        // When the V4File constructor is called
+        new V4File(inputStream);
+
+        // Then the expected exception is thrown
+    }
+
+    @Test
+    public void v4File_BlankLinesIgnored() throws IOException {
+
+        // Given v4 data with a blank observation row
+        String csvHeader = "V4_0,Time_codelist,Time,Geography_codelist,Geography,cpi1dim1aggid,Aggregate\n";
+        String csvRow1 = "88,Month,Oct-00,K02000001,,cpi1dim1A0,CPI (overall index)\n";
+        String csvRow2 = "\n";
+        String csvRow3 = "88,Month,Apr-17,K02000001,,cpi1dim1A0,CPI (overall index)\n";
+        String csvContent = csvHeader + csvRow1 + csvRow2 + csvRow3;
+
+        InputStream inputStream = new ByteArrayInputStream(csvContent.getBytes());
+        final V4File file = new V4File(inputStream);
+        file.groupData();
+
+        // When getOrderedTimeLabels is called.
+        List<String> labels = new ArrayList<>(file.getOrderedTimeLabels());
+
+        // Then the labels are provided in chronological order with the blank row ignored
+        assertThat(labels.get(0)).isEqualTo("Oct-00");
+        assertThat(labels.get(1)).isEqualTo("Apr-17");
+    }
+
     @Test
     public void groupContainsObservations() throws IOException {
         try (final InputStream stream = V4FileTest.class.getResourceAsStream("v4_0.csv")) {
             final V4File file = new V4File(stream);
             final Optional<Group> group = file.groupData().stream().filter(g -> {
-                for (DimensionData data: g.getGroupValues()) {
+                for (DimensionData data : g.getGroupValues()) {
                     if (data.getValue().equals("02.1 Alcoholic beverages")) {
                         return true;
                     }


### PR DESCRIPTION
### What

* Create group objects as each row is read instead of reading all lines
into memory first. This saves a significant amount of memory
* Use an alternative CSV parser that is more efficient. This reduced the CSV parsing time by ~30% and reduces CPU utilisation.

### How to review

Review changes, test.

### Who can review

Anyone
