### PR TITLE
Check for null observation value (handle sparsity)

### DIFF
--- a/src/main/java/dp/xlsx/DatasetFormatter.java
+++ b/src/main/java/dp/xlsx/DatasetFormatter.java
@@ -92,6 +92,12 @@ class DatasetFormatter {
 
             Cell obs = row.createCell(columnOffset);
             final Observation observation = group.getObservation(timeTitle);
+
+            if (observation == null) {
+                columnOffset+= this.file.getAdditionalHeaders().length + 1;
+                continue;
+            }
+
             final String observationValue = observation.getValue();
             setObservationCellValue(obs, observationValue);
             columnOffset++;

--- a/src/test/java/dp/xlsx/DatasetFormatterTest.java
+++ b/src/test/java/dp/xlsx/DatasetFormatterTest.java
@@ -222,6 +222,33 @@ public class DatasetFormatterTest {
     }
 
     @Test
+    public void format_withSparsity() throws IOException {
+
+        // Given some v4 file data sparsity (missing values in the grid)
+        String csvRow1 = "88,Month,Jan-96,K02000001,,cpi1dim1A0,CPI (overall index)\n";
+        String csvRow2 = "88,Month,Jan-97,K02000001,,something else\n";
+        String csvContent = csvHeader + csvRow1 + csvRow2;
+
+        InputStream inputStream = new ByteArrayInputStream(csvContent.getBytes());
+        final V4File file = new V4File(inputStream);
+        final DatasetFormatter datasetFormatter = new DatasetFormatter(workBookStyles, sheet, file, datasetMetadata);
+
+        // When format is called
+        datasetFormatter.format();
+
+        // Then the expected values are in the output
+        assertThat(sheet.getPhysicalNumberOfRows()).isEqualTo(metadataRows + 3);
+
+        Cell cell = sheet.getRow(metadataRows + 1).getCell(3);
+        assertThat(cell.getCellTypeEnum()).isEqualTo(CellType.NUMERIC);
+        assertThat(cell.getNumericCellValue()).isEqualTo(88.0);
+
+        // Then the sparse values are empty
+        cell = sheet.getRow(metadataRows + 1).getCell(4);
+        assertThat(cell.getCellTypeEnum()).isEqualTo(CellType.BLANK);
+    }
+
+    @Test
     public void format_WithUserNotes() throws IOException {
 
         try (final InputStream stream = V4FileTest.class.getResourceAsStream("v4_2.csv")) {


### PR DESCRIPTION
### What

A null pointer exception was being thrown when the output file contained sparsity / blank values. The observation object was null, which also means I could not determine how many columns to skip without looking at the `file.getAdditionalHeaders()` value.

### How to review

Review changes / test. 

### Who can review

Anyone (@Matt-Guest ;))
