### PR TITLE
Remove V4 from split for header to remove case sensitivity

### DIFF
--- a/src/main/java/dp/xlsx/V4File.java
+++ b/src/main/java/dp/xlsx/V4File.java
@@ -51,7 +51,7 @@ class V4File {
 
                 final String v4Code = header[0];
 
-                headerOffset = Integer.parseInt(v4Code.split("V4_")[1]) + 1;
+                headerOffset = Integer.parseInt(v4Code.split("_")[1]) + 1;
                 headerGroup = new Group(header, headerOffset);
                 additionalHeaders = Arrays.copyOfRange(header, 1, headerOffset);
             }


### PR DESCRIPTION
### What

Comparing 'V4_' was a case sensitive comparison, where just the '_' is enough to split on, so have updating the string being compared for the split.

### How to review

Ensure XLSX files continue to generate as expected

### Who can review

Anyone