### PR TITLE
Add max observation config and check count before processing

### DIFF
--- a/src/main/avro/message.avsc
+++ b/src/main/avro/message.avsc
@@ -8,6 +8,7 @@
      {"name": "dataset_id", "type": "string", "default": ""},
      {"name": "edition", "type": "string", "default": ""},
      {"name": "version", "type": "string", "default": ""},
-     {"name": "filename", "type": "string", "default": ""}
+     {"name": "filename", "type": "string", "default": ""},
+     {"name": "row_count", "type": "int", "default": 0}
  ]
 }

--- a/src/main/java/dp/api/filter/FilterAPIClient.java
+++ b/src/main/java/dp/api/filter/FilterAPIClient.java
@@ -64,6 +64,23 @@ public class FilterAPIClient {
         }
     }
 
+    public void setToComplete(final String id) throws JsonProcessingException {
+      final String url = UriComponentsBuilder.fromHttpUrl(filterAPIURL + "/filter-outputs/{filterId}").buildAndExpand(id).toUriString();
+
+      XLSXFile xlsxFile = new XLSXFile();
+      xlsxFile.setSkipped(true);
+
+      final PutFileRequest r = new PutFileRequest(new Downloads(xlsxFile));
+
+      try {
+          LOGGER.info("updating filter api, url : {}, json : {}", url, objectMapper.writeValueAsString(r));
+          restTemplate.put(url, AuthUtils.createHeaders(serviceToken, token, r));
+
+      } catch (RestClientException e) {
+          throw new FilterAPIException("expected 200 status code", e);
+      }
+    }
+
     public Filter getFilter(final String filterID) {
 
         final String url = UriComponentsBuilder

--- a/src/main/java/dp/api/filter/XLSXFile.java
+++ b/src/main/java/dp/api/filter/XLSXFile.java
@@ -16,6 +16,9 @@ public class XLSXFile {
     @JsonProperty("size")
     private String size;
 
+    @JsonProperty("skipped")
+    private Boolean skipped;
+
     public String getPublicUrl() {
         return publicUrl;
     }
@@ -38,5 +41,13 @@ public class XLSXFile {
 
     public void setSize(String size) {
         this.size = size;
+    }
+
+    public Boolean getSkipped() {
+        return skipped;
+    }
+
+    public void setSkipped(Boolean skipped) {
+        this.skipped = skipped;
     }
 }

--- a/src/main/java/dp/api/filter/XLSXFile.java
+++ b/src/main/java/dp/api/filter/XLSXFile.java
@@ -43,7 +43,7 @@ public class XLSXFile {
         this.size = size;
     }
 
-    public Boolean getSkipped() {
+    public Boolean isSkipped() {
         return skipped;
     }
 

--- a/src/main/java/dp/handler/Handler.java
+++ b/src/main/java/dp/handler/Handler.java
@@ -76,6 +76,7 @@ public class Handler {
     @Value("${FILTERED_DATASET_FILE_PREFIX:filtered-datasets/}")
     private String filteredDatasetFilePrefix;
 
+    // 1M row limit in excel - need some buffer for headers/footnotes in file
     @Value("${MAX_OBSERVATION_COUNT:999900}")
     private Integer maxObservationCount;
 

--- a/src/test/java/dp/deserializer/AvroDeserializerTest.java
+++ b/src/test/java/dp/deserializer/AvroDeserializerTest.java
@@ -21,6 +21,7 @@ public class AvroDeserializerTest {
     private String version = "1";
     private String filename = "morty";
     private String s3URL = "s3://bucket/v4.csv";
+    private Integer rowCount = 20000;
 
     @Test(expected = org.apache.kafka.common.errors.SerializationException.class)
     public void invalidAvroMessage() {
@@ -37,13 +38,14 @@ public class AvroDeserializerTest {
         assertThat(exportedFile.getEdition().toString()).isEqualTo(edition);
         assertThat(exportedFile.getVersion().toString()).isEqualTo(version);
         assertThat(exportedFile.getFilename().toString()).isEqualTo(filename);
+        assertThat(exportedFile.getRowCount()).isEqualTo(rowCount);
     }
 
     private byte[] getValidMessageBytes() throws Exception {
         try (ByteArrayOutputStream out = new ByteArrayOutputStream()) {
             BinaryEncoder encoder = EncoderFactory.get().binaryEncoder(out, null);
             DatumWriter<ExportedFile> writer = new SpecificDatumWriter<ExportedFile>(ExportedFile.getClassSchema());
-            ExportedFile f = new ExportedFile(filterID, s3URL, instanceID, datasetID, edition, version, filename);
+            ExportedFile f = new ExportedFile(filterID, s3URL, instanceID, datasetID, edition, version, filename, rowCount);
             writer.write(f, encoder);
             encoder.flush();
             return out.toByteArray();

--- a/src/test/java/dp/handler/HandlerTest.java
+++ b/src/test/java/dp/handler/HandlerTest.java
@@ -162,8 +162,8 @@ public class HandlerTest {
         handler.listen(exportedFile);
 
         verify(datasetAPI, never()).getVersion("/instances/" + instanceID);
-        verify(datasetAPI, never().putVersionDownloads(any(), any());
-        verify(converter, never().toXLSX(any(), any());
+        verify(datasetAPI, never()).putVersionDownloads(any(), any());
+        verify(converter, never()).toXLSX(any(), any());
     }
 
     @Test
@@ -211,7 +211,7 @@ public class HandlerTest {
 
         handler.listen(exportedFile);
 
-        verify(filterAPI, never().getFilter(exportedFile.getFilterId().toString());
+        verify(filterAPI, never()).getFilter(exportedFile.getFilterId().toString());
         verify(filterAPI, times(1)).setToComplete(exportedFile.getFilterId().toString());
         verify(datasetAPI, never()).getMetadata(versionURL);
         verify(converter, never()).toXLSX(any(), any());

--- a/src/test/java/dp/handler/HandlerTest.java
+++ b/src/test/java/dp/handler/HandlerTest.java
@@ -161,9 +161,9 @@ public class HandlerTest {
 
         handler.listen(exportedFile);
 
-        verify(datasetAPI, times(0)).getVersion("/instances/" + instanceID);
-        verify(datasetAPI, times(0)).putVersionDownloads(any(), any());
-        verify(converter, times(0)).toXLSX(any(), any());
+        verify(datasetAPI, never()).getVersion("/instances/" + instanceID);
+        verify(datasetAPI, never().putVersionDownloads(any(), any());
+        verify(converter, never().toXLSX(any(), any());
     }
 
     @Test
@@ -211,10 +211,10 @@ public class HandlerTest {
 
         handler.listen(exportedFile);
 
-        verify(filterAPI, times(0)).getFilter(exportedFile.getFilterId().toString());
+        verify(filterAPI, never().getFilter(exportedFile.getFilterId().toString());
         verify(filterAPI, times(1)).setToComplete(exportedFile.getFilterId().toString());
-        verify(datasetAPI, times(0)).getMetadata(versionURL);
-        verify(converter, times(0)).toXLSX(any(), any());
+        verify(datasetAPI, never()).getMetadata(versionURL);
+        verify(converter, never()).toXLSX(any(), any());
     }
 
     @Test

--- a/src/test/java/dp/handler/HandlerTest.java
+++ b/src/test/java/dp/handler/HandlerTest.java
@@ -103,6 +103,7 @@ public class HandlerTest {
     private String version = "1";
     private String filename = "morty";
     private String versionURL = "/datasets/456/editions/2017/versions/1";
+    private Integer rowCount = 20000;
 
     @Before
     public void setUp() {
@@ -135,7 +136,7 @@ public class HandlerTest {
         when(converter.toXLSX(any(), any())).thenReturn(workBookMock);
 
         final ExportedFile exportedFile = new ExportedFile("", "s3://bucket/datasets/v4.csv", instanceID, datasetID, edition,
-                version, filename);
+                version, filename, rowCount);
 
         handler.listen(exportedFile);
 
@@ -151,6 +152,18 @@ public class HandlerTest {
 
         assertThat("incorrect bucket name", arguments.getValue().getBucketName(), equalTo("csv-exported"));
         assertThat("incorrect filename", arguments.getValue().getKey(), equalTo("full-datasets/morty.xlsx"));
+    }
+
+    @Test
+    public void validFullDownloadTooLarge() throws Exception {
+        final ExportedFile exportedFile = new ExportedFile("", "s3://bucket/datasets/v4.csv", instanceID, datasetID, edition,
+                version, filename, 500000000);
+
+        handler.listen(exportedFile);
+
+        verify(datasetAPI, times(0)).getVersion("/instances/" + instanceID);
+        verify(datasetAPI, times(0)).putVersionDownloads(any(), any());
+        verify(converter, times(0)).toXLSX(any(), any());
     }
 
     @Test
@@ -172,7 +185,7 @@ public class HandlerTest {
 
         when(converter.toXLSX(any(), any())).thenReturn(workbookMock);
 
-        final ExportedFile exportedFile = new ExportedFile("123", "s3://bucket/v4.csv", "12345", "", "", "", "");
+        final ExportedFile exportedFile = new ExportedFile("123", "s3://bucket/v4.csv", "12345", "", "", "", "", rowCount);
 
         handler.listen(exportedFile);
 
@@ -189,6 +202,22 @@ public class HandlerTest {
     }
 
     @Test
+    public void validFilterTooLarge() throws IOException {
+        boolean published = true;
+        Filter filter = createFilter(published);
+        when(filterAPI.getFilter(any())).thenReturn(filter);
+
+        final ExportedFile exportedFile = new ExportedFile("123", "s3://bucket/v4.csv", "12345", "", "", "", "", 500000000);
+
+        handler.listen(exportedFile);
+
+        verify(filterAPI, times(0)).getFilter(exportedFile.getFilterId().toString());
+        verify(filterAPI, times(1)).setToComplete(exportedFile.getFilterId().toString());
+        verify(datasetAPI, times(0)).getMetadata(versionURL);
+        verify(converter, times(0)).toXLSX(any(), any());
+    }
+
+    @Test
     public void filterLinkInvalidError() throws Exception {
         S3Object s3Object = mock(S3Object.class);
         S3ObjectInputStream stream = mock(S3ObjectInputStream.class);
@@ -202,7 +231,7 @@ public class HandlerTest {
         when(s3Client.getUrl(anyString(), anyString())).thenReturn(new URL("https://amazon.com/sdfsdf"));
         when(filterAPI.getFilter(any())).thenReturn(filter);
 
-        final ExportedFile exportedFile = new ExportedFile("123", "s3://bucket/v4.csv", "12345", "", "", "", "");
+        final ExportedFile exportedFile = new ExportedFile("123", "s3://bucket/v4.csv", "12345", "", "", "", "", rowCount);
 
         handler.listen(exportedFile);
 
@@ -228,7 +257,7 @@ public class HandlerTest {
         when(filterAPI.getFilter(any())).thenReturn(filter);
         when(datasetAPI.getMetadata(versionURL)).thenThrow(new FilterAPIException("flubba wubba dub dub", null));
 
-        final ExportedFile exportedFile = new ExportedFile("123", "s3://bucket/v4.csv", "12345", "", "", "", "");
+        final ExportedFile exportedFile = new ExportedFile("123", "s3://bucket/v4.csv", "12345", "", "", "", "", rowCount);
 
         handler.listen(exportedFile);
 
@@ -256,7 +285,7 @@ public class HandlerTest {
         when(datasetAPI.getMetadata(versionURL)).thenReturn(datasetMetadata);
         when(converter.toXLSX(any(), eq(datasetMetadata))).thenThrow(new IOException());
 
-        final ExportedFile exportedFile = new ExportedFile("123", "s3://bucket/v4.csv", "12345", "", "", "", "");
+        final ExportedFile exportedFile = new ExportedFile("123", "s3://bucket/v4.csv", "12345", "", "", "", "", rowCount);
 
         handler.listen(exportedFile);
 
@@ -288,7 +317,7 @@ public class HandlerTest {
         when(converter.toXLSX(any(), eq(datasetMetadata))).thenReturn(workbookMock);
         when(s3Client.putObject(any())).thenThrow(ex);
 
-        final ExportedFile exportedFile = new ExportedFile("123", "s3://bucket/v4.csv", "12345", "", "", "", "");
+        final ExportedFile exportedFile = new ExportedFile("123", "s3://bucket/v4.csv", "12345", "", "", "", "", rowCount);
 
         handler.listen(exportedFile);
 
@@ -324,7 +353,7 @@ public class HandlerTest {
         when(s3Client.putObject(any())).thenReturn(null);
         doThrow(ex).when(filterAPI).addXLSXFile(any(), any(), anyLong(), anyBoolean());
 
-        final ExportedFile exportedFile = new ExportedFile("123", "s3://bucket/v4.csv", "12345", "", "", "", "");
+        final ExportedFile exportedFile = new ExportedFile("123", "s3://bucket/v4.csv", "12345", "", "", "", "", rowCount);
 
         handler.listen(exportedFile);
 
@@ -360,7 +389,7 @@ public class HandlerTest {
 		when(converter.toXLSX(any(), any())).thenReturn(workBookMock);
 
         final ExportedFile exportedFile = new ExportedFile("", "s3://bucket/v4.csv", instanceID, datasetID, edition,
-                version, filename);
+                version, filename, rowCount);
 
         handler.listen(exportedFile);
 
@@ -384,7 +413,7 @@ public class HandlerTest {
         when(s3Client.getObject("bucket", "v4.csv")).thenThrow(mock(SdkClientException.class));
 
         final ExportedFile exportedFile = new ExportedFile("", "s3://bucket/v4.csv", instanceID, datasetID, edition,
-                version, filename);
+                version, filename, rowCount);
 
         handler.listen(exportedFile);
 
@@ -409,7 +438,7 @@ public class HandlerTest {
         when(datasetAPI.getMetadata(anyString())).thenThrow(new FilterAPIException("flubba wubba dub dub", null));
 
         final ExportedFile exportedFile = new ExportedFile("", "s3://bucket/v4.csv", instanceID, datasetID, edition,
-                version, filename);
+                version, filename, rowCount);
 
         handler.listen(exportedFile);
 
@@ -436,7 +465,7 @@ public class HandlerTest {
         when(converter.toXLSX(stream, metadata)).thenThrow(new IOException());
 
         final ExportedFile exportedFile = new ExportedFile("", "s3://bucket/v4.csv", instanceID, datasetID, edition,
-                version, filename);
+                version, filename, rowCount);
 
         handler.listen(exportedFile);
 
@@ -458,7 +487,7 @@ public class HandlerTest {
         when(datasetAPI.getVersion("/instances/123")).thenThrow(new MalformedURLException());
 
         final ExportedFile exportedFile = new ExportedFile("", "s3://bucket/v4.csv", instanceID, datasetID, edition,
-                version, filename);
+                version, filename, rowCount);
 
         handler.listen(exportedFile);
 
@@ -492,7 +521,7 @@ public class HandlerTest {
                 .putVersionDownloads(eq(versionURL), any());
 
         final ExportedFile exportedFile = new ExportedFile("", "s3://bucket/v4.csv", instanceID, datasetID, edition,
-                version, filename);
+                version, filename, rowCount);
 
         handler.listen(exportedFile);
 
@@ -532,7 +561,7 @@ public class HandlerTest {
         when(converter.toXLSX(any(), any())).thenReturn(workbookMock);
         when(s3Client.putObject(any())).thenThrow(new RuntimeException());
 
-        final ExportedFile exportedFile = new ExportedFile("123", "s3://bucket/v4.csv", "", "", "", "", "");
+        final ExportedFile exportedFile = new ExportedFile("123", "s3://bucket/v4.csv", "", "", "", "", "", rowCount);
 
         try {
             handler.listen(exportedFile);


### PR DESCRIPTION
### What

add configurable max observation count to be able to limit production of excel files when more than that number of observations exists

set skipped flag on filter outputs
do not need to update datasets for full outputs

### How to review

goes with:
https://github.com/ONSdigital/dp-dataset-exporter/pull/58
https://github.com/ONSdigital/dp-filter-api/pull/112

check everything works

### Who can review

anyone