### PR TITLE
Update time sorting to make more use of the code/label V4 structure

### DIFF
--- a/src/main/java/dp/xlsx/V4File.java
+++ b/src/main/java/dp/xlsx/V4File.java
@@ -126,7 +126,8 @@ class V4File {
         String first = timeLabels.entrySet().iterator().next().getKey();
         String format = DateLabel.determineDateFormat(first);
 
-        // if the format is not recognised - return alphabetically (treemap naturally sorts)
+        // if the format is not recognised - return alphabetically
+        // treemap naturally sorts on keys, but we need to sort the values
         if (StringUtils.isEmpty(format)) {
             TreeMap<String, String> timeLabels = getUniqueTimeLabels();
             ArrayList<String> labels = new ArrayList<>(timeLabels.values());

--- a/src/main/java/dp/xlsx/V4File.java
+++ b/src/main/java/dp/xlsx/V4File.java
@@ -129,7 +129,9 @@ class V4File {
         // if the format is not recognised - return alphabetically (treemap naturally sorts)
         if (StringUtils.isEmpty(format)) {
             TreeMap<String, String> timeLabels = getUniqueTimeLabels();
-            return timeLabels.values();
+            ArrayList<String> labels = new ArrayList<>(timeLabels.values());
+            Collections.sort(labels);
+            return labels;
         }
 
         DateFormat dateFormat = new SimpleDateFormat(format);

--- a/src/test/java/dp/xlsx/DatasetFormatterTest.java
+++ b/src/test/java/dp/xlsx/DatasetFormatterTest.java
@@ -31,8 +31,8 @@ public class DatasetFormatterTest {
     public void timeValuesAreOrderedAlphabeticallyWhenUnrecognised() throws IOException {
 
         // Given some V4 input data
-        String csvRow = "45.2,Month,January-96,K02000001,Great Britain,cpi1dim1A0,CPI (overall index)\n";
-        String csvRow2 = "86.9,Month,February-96,K02000001,Great Britain,cpi1dim1A0,CPI (overall index)\n";
+        String csvRow = "45.2,January-96,Jan 1996,K02000001,Great Britain,cpi1dim1A0,CPI (overall index)\n";
+        String csvRow2 = "86.9,February-96,Feb 1996,K02000001,Great Britain,cpi1dim1A0,CPI (overall index)\n";
         String csvContent = csvHeader + csvRow + csvRow2;
 
         InputStream inputStream = new ByteArrayInputStream(csvContent.getBytes());
@@ -43,16 +43,16 @@ public class DatasetFormatterTest {
         // When format is called
         datasetFormatter.format();
 
-        assertThat(sheet.getRow(metadataRows + 0).getCell(3).getStringCellValue()).isEqualTo("February-96");
-        assertThat(sheet.getRow(metadataRows + 0).getCell(4).getStringCellValue()).isEqualTo("January-96");
+        assertThat(sheet.getRow(metadataRows + 0).getCell(3).getStringCellValue()).isEqualTo("Feb 1996");
+        assertThat(sheet.getRow(metadataRows + 0).getCell(4).getStringCellValue()).isEqualTo("Jan 1996");
     }
 
     @Test
     public void timeValuesAreOrderedChronologicallyWhenRecognised() throws IOException {
 
         // Given some V4 input data
-        String csvRow = "45.2,Month,Jan-96,K02000001,Great Britain,cpi1dim1A0,CPI (overall index)\n";
-        String csvRow2 = "86.9,Month,Feb-96,K02000001,Great Britain,cpi1dim1A0,CPI (overall index)\n";
+        String csvRow = "45.2,Jan-96,January 1996,K02000001,Great Britain,cpi1dim1A0,CPI (overall index)\n";
+        String csvRow2 = "86.9,Feb-96,February 1996,K02000001,Great Britain,cpi1dim1A0,CPI (overall index)\n";
         String csvContent = csvHeader + csvRow + csvRow2;
 
         InputStream inputStream = new ByteArrayInputStream(csvContent.getBytes());
@@ -62,16 +62,16 @@ public class DatasetFormatterTest {
         // When format is called
         datasetFormatter.format();
 
-        assertThat(sheet.getRow(metadataRows + 0).getCell(3).getStringCellValue()).isEqualTo("Jan-96");
-        assertThat(sheet.getRow(metadataRows + 0).getCell(4).getStringCellValue()).isEqualTo("Feb-96");
+        assertThat(sheet.getRow(metadataRows + 0).getCell(3).getStringCellValue()).isEqualTo("January 1996");
+        assertThat(sheet.getRow(metadataRows + 0).getCell(4).getStringCellValue()).isEqualTo("February 1996");
     }
 
     @Test
     public void dimensionsAreOrderedByV4FileOrder() throws IOException {
 
         // Given some V4 input data
-        String csvRow = "45.2,Month,Jan-96,K02000002,Wales,cpi1dim1A1,AAA\n";
-        String csvRow2 = "86.9,Month,Jan-96,K02000003,England,cpi1dim1A2,BBB\n";
+        String csvRow = "45.2,Jan-96,January 1996,K02000002,Wales,cpi1dim1A1,AAA\n";
+        String csvRow2 = "86.9,Jan-96,January 1996,K02000003,England,cpi1dim1A2,BBB\n";
         String csvContent = csvHeader + csvRow + csvRow2;
 
         InputStream inputStream = new ByteArrayInputStream(csvContent.getBytes());
@@ -112,7 +112,7 @@ public class DatasetFormatterTest {
         String expectedTitle = "expected title";
         datasetMetadata.setTitle(expectedTitle);
 
-        String csvRow = ",Month,Jan-96,K02000001,,cpi1dim1A0,CPI (overall index)\n";
+        String csvRow = ",Jan-96,January 1996,K02000001,,cpi1dim1A0,CPI (overall index)\n";
         String csvContent = csvHeader + csvRow;
 
         InputStream inputStream = new ByteArrayInputStream(csvContent.getBytes());
@@ -133,7 +133,7 @@ public class DatasetFormatterTest {
     public void format_WithEmptyObservation() throws IOException {
 
         // Given some v4 file data with an empty observation field
-        String csvRow = ",Month,Jan-96,K02000001,,cpi1dim1A0,CPI (overall index)\n";
+        String csvRow = ",Jan-96,January 1996,K02000001,,cpi1dim1A0,CPI (overall index)\n";
         String csvContent = csvHeader + csvRow;
 
         InputStream inputStream = new ByteArrayInputStream(csvContent.getBytes());
@@ -153,7 +153,7 @@ public class DatasetFormatterTest {
     public void format_ZeroDecimal() throws IOException {
 
         // Given some v4 file data with an observation that has a zero decimal place (88.0)
-        String csvRow = "88.0,Month,Jan-96,K02000001,,cpi1dim1A0,CPI (overall index)\n";
+        String csvRow = "88.0,Jan-96,January 1996,K02000001,,cpi1dim1A0,CPI (overall index)\n";
         String csvContent = csvHeader + csvRow;
 
         InputStream inputStream = new ByteArrayInputStream(csvContent.getBytes());
@@ -176,7 +176,7 @@ public class DatasetFormatterTest {
     public void format_NoDecimal() throws IOException {
 
         // Given some v4 file data with an observation that has a zero decimal place (88.0)
-        String csvRow = "88,Month,Jan-96,K02000001,,cpi1dim1A0,CPI (overall index)\n";
+        String csvRow = "88,Jan-96,January 1996,K02000001,,cpi1dim1A0,CPI (overall index)\n";
         String csvContent = csvHeader + csvRow;
 
         InputStream inputStream = new ByteArrayInputStream(csvContent.getBytes());
@@ -225,8 +225,8 @@ public class DatasetFormatterTest {
     public void format_withSparsity() throws IOException {
 
         // Given some v4 file data sparsity (missing values in the grid)
-        String csvRow1 = "88,Month,Jan-96,K02000001,,cpi1dim1A0,CPI (overall index)\n";
-        String csvRow2 = "85,Month,Jan-97,K02000001,,cpi1dim1A1,something else\n";
+        String csvRow1 = "88,Jan-96,January 1996,K02000001,,cpi1dim1A0,CPI (overall index)\n";
+        String csvRow2 = "85,Jan-97,January 1997,K02000001,,cpi1dim1A1,something else\n";
         String csvContent = csvHeader + csvRow1 + csvRow2;
 
         InputStream inputStream = new ByteArrayInputStream(csvContent.getBytes());

--- a/src/test/java/dp/xlsx/V4FileTest.java
+++ b/src/test/java/dp/xlsx/V4FileTest.java
@@ -41,9 +41,9 @@ public class V4FileTest {
 
         // Given v4 data with a blank observation row
         String csvHeader = "V4_0,Time_codelist,Time,Geography_codelist,Geography,cpi1dim1aggid,Aggregate\n";
-        String csvRow1 = "88,Month,Oct-00,K02000001,,cpi1dim1A0,CPI (overall index)\n";
+        String csvRow1 = "88,Oct-00,October 2000,K02000001,,cpi1dim1A0,CPI (overall index)\n";
         String csvRow2 = "\n";
-        String csvRow3 = "88,Month,Apr-17,K02000001,,cpi1dim1A0,CPI (overall index)\n";
+        String csvRow3 = "88,Apr-17,April 2017,K02000001,,cpi1dim1A0,CPI (overall index)\n";
         String csvContent = csvHeader + csvRow1 + csvRow2 + csvRow3;
 
         InputStream inputStream = new ByteArrayInputStream(csvContent.getBytes());
@@ -54,8 +54,8 @@ public class V4FileTest {
         List<String> labels = new ArrayList<>(file.getOrderedTimeLabels());
 
         // Then the labels are provided in chronological order with the blank row ignored
-        assertThat(labels.get(0)).isEqualTo("Oct-00");
-        assertThat(labels.get(1)).isEqualTo("Apr-17");
+        assertThat(labels.get(0)).isEqualTo("October 2000");
+        assertThat(labels.get(1)).isEqualTo("April 2017");
     }
 
     @Test
@@ -81,9 +81,9 @@ public class V4FileTest {
 
         // Given v4 data with time labels in a recognised format.
         String csvHeader = "V4_0,Time_codelist,Time,Geography_codelist,Geography,cpi1dim1aggid,Aggregate\n";
-        String csvRow1 = "88,Month,Oct-00,K02000001,,cpi1dim1A0,CPI (overall index)\n";
-        String csvRow2 = "88,Month,Jan-96,K02000001,,cpi1dim1A0,CPI (overall index)\n";
-        String csvRow3 = "88,Month,Apr-17,K02000001,,cpi1dim1A0,CPI (overall index)\n";
+        String csvRow1 = "88,Oct-00,October 2000,K02000001,,cpi1dim1A0,CPI (overall index)\n";
+        String csvRow2 = "88,Jan-96,January 1996,K02000001,,cpi1dim1A0,CPI (overall index)\n";
+        String csvRow3 = "88,Apr-17,April 2017,K02000001,,cpi1dim1A0,CPI (overall index)\n";
         String csvContent = csvHeader + csvRow1 + csvRow2 + csvRow3;
 
         InputStream inputStream = new ByteArrayInputStream(csvContent.getBytes());
@@ -94,9 +94,9 @@ public class V4FileTest {
         List<String> labels = new ArrayList<>(file.getOrderedTimeLabels());
 
         // Then the labels are provided in chronological order.
-        assertThat(labels.get(0)).isEqualTo("Jan-96");
-        assertThat(labels.get(1)).isEqualTo("Oct-00");
-        assertThat(labels.get(2)).isEqualTo("Apr-17");
+        assertThat(labels.get(0)).isEqualTo("January 1996");
+        assertThat(labels.get(1)).isEqualTo("October 2000");
+        assertThat(labels.get(2)).isEqualTo("April 2017");
     }
 
     @Test
@@ -104,9 +104,9 @@ public class V4FileTest {
 
         // Given v4 data with time labels in an unrecognised format.
         String csvHeader = "V4_0,Time_codelist,Time,Geography_codelist,Geography,cpi1dim1aggid,Aggregate\n";
-        String csvRow1 = "88,Month,10-00,K02000001,,cpi1dim1A0,CPI (overall index)\n";
-        String csvRow2 = "88,Month,01-96,K02000001,,cpi1dim1A0,CPI (overall index)\n";
-        String csvRow3 = "88,Month,11-17,K02000001,,cpi1dim1A0,CPI (overall index)\n";
+        String csvRow1 = "88,10-00,Oct 00,K02000001,,cpi1dim1A0,CPI (overall index)\n";
+        String csvRow2 = "88,01-96,Jan 96,K02000001,,cpi1dim1A0,CPI (overall index)\n";
+        String csvRow3 = "88,11-17,Nov 17,K02000001,,cpi1dim1A0,CPI (overall index)\n";
         String csvContent = csvHeader + csvRow1 + csvRow2 + csvRow3;
 
         InputStream inputStream = new ByteArrayInputStream(csvContent.getBytes());
@@ -117,16 +117,16 @@ public class V4FileTest {
         List<String> labels = new ArrayList<>(file.getOrderedTimeLabels());
 
         // Then the labels are provided in alphabetical order.
-        assertThat(labels.get(0)).isEqualTo("01-96");
-        assertThat(labels.get(1)).isEqualTo("10-00");
-        assertThat(labels.get(2)).isEqualTo("11-17");
+        assertThat(labels.get(0)).isEqualTo("Jan 96");
+        assertThat(labels.get(1)).isEqualTo("Oct 00");
+        assertThat(labels.get(2)).isEqualTo("Nov 17");
     }
 
     @Test
     public void getDimensions_ReturnsAllButFirstTimeDimension() throws Exception {
 
         String csvHeader = "V4_0,Time_codelist,Time,Geography_codelist,Geography,cpi1dim1aggid,Aggregate\n";
-        String csvRow1 = "88,Month,10-00,K02000001,,cpi1dim1A0,CPI (overall index)\n";
+        String csvRow1 = "88,10-00,Oct 00,K02000001,,cpi1dim1A0,CPI (overall index)\n";
         String csvContent = csvHeader + csvRow1;
 
         InputStream inputStream = new ByteArrayInputStream(csvContent.getBytes());

--- a/src/test/java/dp/xlsx/V4FileTest.java
+++ b/src/test/java/dp/xlsx/V4FileTest.java
@@ -118,8 +118,8 @@ public class V4FileTest {
 
         // Then the labels are provided in alphabetical order.
         assertThat(labels.get(0)).isEqualTo("Jan 96");
-        assertThat(labels.get(1)).isEqualTo("Oct 00");
-        assertThat(labels.get(2)).isEqualTo("Nov 17");
+        assertThat(labels.get(1)).isEqualTo("Nov 17");
+        assertThat(labels.get(2)).isEqualTo("Oct 00");
     }
 
     @Test


### PR DESCRIPTION
### What

Previously, we were only making use of the label column, expecting the codes which matched our understood `mmm-yy` format to be in the label column in breach of V4 file standards. This was due to not having proper code lists for time.

Now that we have code lists, and are loading codes and labels into the V4 file, the output generation needs to take in both pieces of info, check the _codes_ for whether they match an understood format, and then output labels in a sensible order.

### How to review

check xlsx outputs behave as expected

If codes match a format -> codes are converted to times, sorted chronologically, and then the corresponding labels are returned in chronological order

if codes do not match a format -> labels are sorted alphabetically

### Who can review

anyone