### PR TITLE
Feature/s3 bucket url

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Ensure you have vault running.
 * Run the auth-stub-api or Zebedee for authentication
 * Setup AWS credentials. The app uses the default provider chain. When running locally this typically means they are provided by the `~/.aws/credentials` file.  Alternatively you can inject the credentials via environment variables as described in the configuration section
 
-To quickly run the service locally run `make debug`. 
+To quickly run the service locally run `make debug`.
 
 ### Kafka scripts
 

--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ Scripts for updating and debugging Kafka can be found [here](https://github.com/
 | AWS_SECRET_ACCESS_KEY       | access-key-secret                    | AWS secret key for s3 (must be provided)
 | S3_REGION                   | eu-west-1                            | AWS region for S3
 | S3_BUCKET_NAME              | csv-exported                         | AWS bucket to store the XLSX files
+| S3_BUCKET_URL               | _unset_     (e.g. `https://cf.host`) | If set, the URL prefix for public, exported downloads
 | FILTER_API_URL              | http://localhost:22100               | Filter api URL
 | FILTER_API_AUTH_TOKEN       | FD0108EA-825D-411C-9B1D-41EF7727F465 | Secret token to use the Filter api
 | DATASET_API_URL             | http://localhost:22000               | Dataset api URL

--- a/src/main/java/dp/api/dataset/WorkbookDetails.java
+++ b/src/main/java/dp/api/dataset/WorkbookDetails.java
@@ -5,29 +5,29 @@ package dp.api.dataset;
  */
 public class WorkbookDetails {
 
-    private String dowloadURI;
+    private String downloadURI;
     private long contentLength;
 
     /**
      * Create new Workbook details.
      *
-     * @param dowloadURI    the S3 URL to the download file.
+     * @param downloadURI    the S3 URL to the download file.
      * @param contentLength the size of the download file.
      */
-    public WorkbookDetails(String dowloadURI, long contentLength) {
-        this.dowloadURI = dowloadURI;
+    public WorkbookDetails(String downloadURI, long contentLength) {
+        this.downloadURI = downloadURI;
         this.contentLength = contentLength;
     }
 
     /**
      * @return the S3 URL to the download file.
      */
-    public String getDowloadURI() {
-        return dowloadURI;
+    public String getDownloadURI() {
+        return downloadURI;
     }
 
-    public void setDowloadURI(String dowloadURI) {
-        this.dowloadURI = dowloadURI;
+    public void setDownloadURI(String downloadURI) {
+        this.downloadURI = downloadURI;
     }
 
     /**
@@ -51,14 +51,14 @@ public class WorkbookDetails {
 
         return new org.apache.commons.lang3.builder.EqualsBuilder()
                 .append(getContentLength(), that.getContentLength())
-                .append(getDowloadURI(), that.getDowloadURI())
+                .append(getDownloadURI(), that.getDownloadURI())
                 .isEquals();
     }
 
     @Override
     public int hashCode() {
         return new org.apache.commons.lang3.builder.HashCodeBuilder(17, 37)
-                .append(getDowloadURI())
+                .append(getDownloadURI())
                 .append(getContentLength())
                 .toHashCode();
     }

--- a/src/main/java/dp/api/filter/FilterAPIClient.java
+++ b/src/main/java/dp/api/filter/FilterAPIClient.java
@@ -38,7 +38,7 @@ public class FilterAPIClient {
     @Autowired
     private ObjectMapper objectMapper;
 
-    public void addXLSXFile(final String id, final String s3Location, final long size, boolean filterIsPublished) throws JsonProcessingException {
+    public void addXLSXFile(final String id, final String s3Location, final String s3PublicUrl, final long size, boolean filterIsPublished) throws JsonProcessingException {
 
         final String url = UriComponentsBuilder.fromHttpUrl(filterAPIURL + "/filter-outputs/{filterId}").buildAndExpand(id).toUriString();
         final String sizeToString = Long.toString(size);
@@ -47,7 +47,7 @@ public class FilterAPIClient {
         xlsxFile.setSize(sizeToString);
 
         if (filterIsPublished) {
-            xlsxFile.setPublicUrl(s3Location);
+            xlsxFile.setPublicUrl(s3PublicUrl);
         } else {
             xlsxFile.setPrivateUrl(s3Location);
         }

--- a/src/main/java/dp/handler/Handler.java
+++ b/src/main/java/dp/handler/Handler.java
@@ -311,7 +311,7 @@ public class Handler {
                 throw new FilterAPIException("error while attempting PUT XLSX workbook to S3 bucket", e);
             }
         } catch (IOException e) {
-            LOGGER.error("error while attempting create XLSX workbook, filename: {}, bucket: {}", filename);
+            LOGGER.error("error while attempting create XLSX workbook, filename: {}, bucket: {}", filename, bucket);
             throw e;
         }
     }

--- a/src/test/java/dp/handler/HandlerTest.java
+++ b/src/test/java/dp/handler/HandlerTest.java
@@ -240,7 +240,7 @@ public class HandlerTest {
         verify(datasetAPI, never()).getMetadata(anyString());
         verify(converter, never()).toXLSX(any(), any());
         verify(s3Client, never()).putObject(any());
-        verify(filterAPI, never()).addXLSXFile(any(), any(), anyLong(), anyBoolean());
+        verify(filterAPI, never()).addXLSXFile(any(), any(), any(), anyLong(), anyBoolean());
     }
 
     @Test
@@ -266,7 +266,7 @@ public class HandlerTest {
         verify(datasetAPI, times(1)).getMetadata(versionURL);
         verify(converter, never()).toXLSX(any(), any());
         verify(s3Client, never()).putObject(any());
-        verify(filterAPI, never()).addXLSXFile(any(), any(), anyLong(), anyBoolean());
+        verify(filterAPI, never()).addXLSXFile(any(), any(), any(), anyLong(), anyBoolean());
     }
 
     @Test
@@ -293,7 +293,7 @@ public class HandlerTest {
         verify(filterAPI, times(1)).getFilter(exportedFile.getFilterId().toString());
         verify(datasetAPI, times(1)).getMetadata(versionURL);
         verify(converter, times(1)).toXLSX(any(), eq(datasetMetadata));
-        verify(filterAPI, never()).addXLSXFile(any(), any(), anyLong(), anyBoolean());
+        verify(filterAPI, never()).addXLSXFile(any(), any(), any(), anyLong(), anyBoolean());
         verify(s3Client, never()).putObject(any());
     }
 
@@ -326,7 +326,7 @@ public class HandlerTest {
         verify(datasetAPI, times(1)).getMetadata(versionURL);
         verify(converter, times(1)).toXLSX(any(), eq(datasetMetadata));
         verify(s3Client, times(1)).putObject(arguments.capture());
-        verify(filterAPI, never()).addXLSXFile(any(), any(), anyLong(), anyBoolean());
+        verify(filterAPI, never()).addXLSXFile(any(), any(), any(), anyLong(), anyBoolean());
 
         assertThat("incorrect bucket name", arguments.getValue().getBucketName(), equalTo("csv-exported"));
         assertThat("incorrect filename", arguments.getValue().getKey(), equalTo("filtered-datasets/123.xlsx"));
@@ -351,7 +351,7 @@ public class HandlerTest {
         when(datasetAPI.getMetadata(versionURL)).thenReturn(datasetMetadata);
         when(converter.toXLSX(any(), eq(datasetMetadata))).thenReturn(workbookMock);
         when(s3Client.putObject(any())).thenReturn(null);
-        doThrow(ex).when(filterAPI).addXLSXFile(any(), any(), anyLong(), anyBoolean());
+        doThrow(ex).when(filterAPI).addXLSXFile(any(), any(), any(), anyLong(), anyBoolean());
 
         final ExportedFile exportedFile = new ExportedFile("123", "s3://bucket/v4.csv", "12345", "", "", "", "", rowCount);
 
@@ -362,14 +362,14 @@ public class HandlerTest {
         verify(datasetAPI, times(1)).getMetadata(versionURL);
         verify(converter, times(1)).toXLSX(any(), eq(datasetMetadata));
         verify(s3Client, times(1)).putObject(arguments.capture());
-        verify(filterAPI, times(1)).addXLSXFile(any(), any(), anyLong(), anyBoolean());
+        verify(filterAPI, times(1)).addXLSXFile(any(), any(), any(), anyLong(), anyBoolean());
 
         assertThat("incorrect buck name", arguments.getValue().getBucketName(), equalTo("csv-exported"));
         assertThat("incorrect filename", arguments.getValue().getKey(), equalTo("filtered-datasets/123.xlsx"));
     }
 
     @Test
-    public void vaildExportFilePrePublishMessage() throws Exception {
+    public void validExportFilePrePublishMessage() throws Exception {
         S3Object s3Object = mock(S3Object.class);
         S3ObjectInputStream stream = mock(S3ObjectInputStream.class);
 
@@ -405,7 +405,7 @@ public class HandlerTest {
     }
 
     @Test
-    public void vaildPrePublishMessageGetObjectError() throws Exception {
+    public void validPrePublishMessageGetObjectError() throws Exception {
         Version ver = new Version();
         ver.setState("published");
 
@@ -426,7 +426,7 @@ public class HandlerTest {
     }
 
     @Test
-    public void vaildPrePublishMessageGetMetadataError() throws Exception {
+    public void validPrePublishMessageGetMetadataError() throws Exception {
         S3Object s3Object = mock(S3Object.class);
 
         Version ver = new Version();
@@ -451,7 +451,7 @@ public class HandlerTest {
     }
 
     @Test
-    public void vaildPrePublishMessageConvertToXLSError() throws Exception {
+    public void validPrePublishMessageConvertToXLSError() throws Exception {
         S3Object s3Object = mock(S3Object.class);
         S3ObjectInputStream stream = mock(S3ObjectInputStream.class);
         Metadata metadata = new Metadata();
@@ -501,7 +501,7 @@ public class HandlerTest {
     }
 
     @Test
-    public void vaildPrePublishMessagePutVersionDatasetAPIError() throws Exception {
+    public void validPrePublishMessagePutVersionDatasetAPIError() throws Exception {
         S3Object s3Object = mock(S3Object.class);
         S3ObjectInputStream stream = mock(S3ObjectInputStream.class);
         ArgumentCaptor<PutObjectRequest> arguments = ArgumentCaptor.forClass(PutObjectRequest.class);

--- a/src/test/java/dp/handler/HandlerTest.java
+++ b/src/test/java/dp/handler/HandlerTest.java
@@ -116,7 +116,6 @@ public class HandlerTest {
         S3Object s3Object = mock(S3Object.class);
         S3ObjectInputStream stream = mock(S3ObjectInputStream.class);
 
-        SXSSFWorkbook workBookMock = mock(SXSSFWorkbook.class);
         ArgumentCaptor<PutObjectRequest> arguments = ArgumentCaptor.forClass(PutObjectRequest.class);
         ArgumentCaptor<DownloadsList> downLoadArguments = ArgumentCaptor.forClass(DownloadsList.class);
 
@@ -135,7 +134,7 @@ public class HandlerTest {
         when(s3Crypto.getObjectWithPSK("bucket", "datasets/v4.csv", "test-key".getBytes())).thenReturn(s3Object);
         when(s3Client.getUrl(anyString(), anyString())).thenReturn(new URL("https://amazon.com/datasets/morty.xlsx"));
         when(datasetAPI.getMetadata("/instances/123")).thenReturn(datasetMetadata);
-        when(converter.toXLSX(any(), any())).thenReturn(workBookMock);
+        when(converter.toXLSX(any(), any())).thenReturn(workbookMock);
 
         final ExportedFile exportedFile = new ExportedFile("", "s3://bucket/datasets/v4.csv", instanceID, datasetID, edition,
                 version, filename, rowCount);
@@ -144,7 +143,7 @@ public class HandlerTest {
 
         verify(datasetAPI, times(1)).getVersion("/instances/" + instanceID);
         verify(datasetAPI, times(1)).putVersionDownloads(any(), downLoadArguments.capture());
-        verify(workBookMock, times(1)).write(any(OutputStream.class));
+        verify(workbookMock, times(1)).write(any(OutputStream.class));
         verify(vaultTemplate, times(1)).read("secret/shared/psk/v4.csv");
         verify(vaultResponse, times(1)).getData();
         verify(vaultTemplate, times(1)).write(eq("secret/shared/psk/morty.xlsx"), any());
@@ -374,7 +373,6 @@ public class HandlerTest {
         S3Object s3Object = mock(S3Object.class);
         S3ObjectInputStream stream = mock(S3ObjectInputStream.class);
 
-        SXSSFWorkbook workBookMock = mock(SXSSFWorkbook.class);
         ArgumentCaptor<PutObjectRequest> arguments = ArgumentCaptor.forClass(PutObjectRequest.class);
 
         Metadata datasetMetadata = new Metadata();
@@ -387,7 +385,7 @@ public class HandlerTest {
 		when(s3Client.getObject("bucket", "v4.csv")).thenReturn(s3Object);
 		when(s3Client.getUrl(anyString(), anyString())).thenReturn(new URL("https://amazon.com/morty.xlsx"));
 		when(datasetAPI.getMetadata(versionURL)).thenReturn(datasetMetadata);
-		when(converter.toXLSX(any(), any())).thenReturn(workBookMock);
+		when(converter.toXLSX(any(), any())).thenReturn(workbookMock);
 
         final ExportedFile exportedFile = new ExportedFile("", "s3://bucket/v4.csv", instanceID, datasetID, edition,
                 version, filename, rowCount);
@@ -398,7 +396,7 @@ public class HandlerTest {
 		verify(datasetAPI, times(1)).getMetadata(versionURL);
 		verify(converter, times(1)).toXLSX(any(), any());
 		verify(datasetAPI, times(1)).putVersionDownloads(any(), any());
-		verify(workBookMock, times(1)).write(any(OutputStream.class));
+		verify(workbookMock, times(1)).write(any(OutputStream.class));
 		verify(s3Client, times(1)).putObject(arguments.capture());
 
         assertThat("incorrect bucket name", arguments.getValue().getBucketName(), equalTo("csv-exported"));


### PR DESCRIPTION
### What

new option to have a special URL (prefix) for the s3 bucket - used for public/published datasets (full and filtered)

### How to review

try the filter journey with and without the env var set (expected to be used only in production), ensure the URL is still valid

this change should be released alongside the equivalent change for CSVs - https://github.com/ONSdigital/dp-dataset-exporter/pull/79
and secrets: https://github.com/ONSdigital/dp-ci/pull/740

### Who can review

you