### PR TITLE
Don't kill service if it fails to authenticate with Zebedee

### DIFF
--- a/src/main/java/dp/api/authentication/AuthenicateOnStartUp.java
+++ b/src/main/java/dp/api/authentication/AuthenicateOnStartUp.java
@@ -39,8 +39,7 @@ public class AuthenicateOnStartUp implements ApplicationListener<ApplicationRead
         // If no url to zebedee is provided we assume the app is running on the webnet. As zebedee
         // will only be accessible from the publishing subnet
         if (StringUtils.isNotEmpty(zebedee_url) && !isAuthenticated()) {
-            LOGGER.error("failed to authenticate against zebedee closing app");
-            System.exit(1);
+            LOGGER.error("Failed to authenticate against zebedee. Please, try to authenticate again later");
         }
     }
 


### PR DESCRIPTION
### What

The component AuthenticateOnStartUp is executed on the ApplicationReadyEvent. At this point, we try to authenticate with Zebedee, and if it failed, the service died. In this PR I log the authentication failure and keep running instead. This means that in the future we might want to re-try to authenticate at runtime or rely on other services to authenticate the token for us.

note: the service should die if vault is not running because the AUTH_TOKEN env will not exist and this would be considered a config issue (i.e. the AUTH_TOKEN is generated by the Makefile calling Vault)

### How to review

- 'make debug' with all dependencies running -> should be ok
- 'make debug' service with only vault running -> should be ok  (before this change, it would die because it couldn't authenticate with Zebedee)
- 'make debug' service without vault running -> should die

### Who can review

anyone.