### PR TITLE
Fix if statement for handling s3 urls

### DIFF
--- a/src/main/java/dp/handler/Handler.java
+++ b/src/main/java/dp/handler/Handler.java
@@ -169,7 +169,7 @@ public class Handler {
 
     private String getSafeS3URL(String url) {
         String s3uri = url;
-        if (!StringUtils.isEmpty(s3uri) && s3uri.startsWith(bucketUrl)) {
+        if (!StringUtils.isEmpty(bucketUrl) && s3uri.startsWith(bucketUrl)) {
             s3uri = s3uri.replace(bucketUrl, bucketUrl + ".s3.eu-west-1.amazonaws.com");
         }
         return s3uri;

--- a/src/main/java/dp/handler/Handler.java
+++ b/src/main/java/dp/handler/Handler.java
@@ -167,7 +167,7 @@ public class Handler {
       }
     }
 
-    private String getSafeS3URL(String url) {
+    public String getSafeS3URL(String url) {
         String s3uri = url;
         if (!StringUtils.isEmpty(bucketUrl) && s3uri.startsWith(bucketUrl)) {
             s3uri = s3uri.replace(bucketUrl, bucketUrl + ".s3.eu-west-1.amazonaws.com");

--- a/src/test/java/dp/handler/HandlerTest.java
+++ b/src/test/java/dp/handler/HandlerTest.java
@@ -110,7 +110,6 @@ public class HandlerTest {
     @Before
     public void setUp() {
         MockitoAnnotations.initMocks(this);
-        handler.setBucketUrl(bucketURL);
     }
 
     @Test
@@ -156,6 +155,23 @@ public class HandlerTest {
         assertThat("public URL should be empty", downLoadArguments.getValue().getXls().getPublicState(), equalTo(null));
         assertThat("incorrect bucket name", arguments.getValue().getBucketName(), equalTo("csv-exported"));
         assertThat("incorrect filename", arguments.getValue().getKey(), equalTo("full-datasets/morty.xlsx"));
+    }
+
+    @Test
+    public void appendS3uri() throws Exception {
+        handler.setBucketUrl("test-bucket");
+
+        String s3uri = handler.getSafeS3URL("test-bucket");
+
+        assertThat("correctly appends the s3uri value", s3uri, equalTo("test-bucket.s3.eu-west-1.amazonaws.com"));
+
+        handler.setBucketUrl("");
+    }
+
+    public void doesNotappendS3uri() throws Exception {
+        String s3uri = handler.getSafeS3URL("test-bucket");
+
+        assertThat("correctly appends the s3uri value", s3uri, equalTo("test-bucket"));
     }
 
     @Test


### PR DESCRIPTION
### What

Depending on whether the url ir post-fix with `.s3.eu-west-1.amazonaws.com` or not then manipulation of the url may need to take place so that the s3 library can handle new s3 urls.

### How to review

Check changes make sense, should handle two cases where the s3 url does contain`.s3.eu-west-1.amazonaws.com` and when it doesn't appends it to the s3URL, prior to calling AmazonS3URI from aws s3 java library

### Who can review

Anyone
