### PR TITLE
Feature/fix s3url

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ Scripts for updating and debugging Kafka can be found [here](https://github.com/
 | S3_REGION                   | eu-west-1                            | AWS region for S3
 | S3_BUCKET_NAME              | csv-exported                         | AWS bucket to store the XLSX files
 | S3_BUCKET_URL               | _unset_     (e.g. `https://cf.host`) | If set, the URL prefix for public, exported downloads
+| S3_BUCKET_S3_URL            | _unset_  (e.g. `https://bkt.s3.aws`) | If set, S3-friendly URL prefix replacing S3_BUCKET_URL for obtaining CSV
 | FILTER_API_URL              | http://localhost:22100               | Filter api URL
 | FILTER_API_AUTH_TOKEN       | FD0108EA-825D-411C-9B1D-41EF7727F465 | Secret token to use the Filter api
 | DATASET_API_URL             | http://localhost:22000               | Dataset api URL

--- a/src/main/java/dp/handler/Handler.java
+++ b/src/main/java/dp/handler/Handler.java
@@ -169,7 +169,7 @@ public class Handler {
 
     private String getSafeS3URL(String url) {
         String s3uri = url;
-        if (!StringUtils.isEmpty(s3uri) && s3uri.startsWith(bucketUrl)) {
+        if (!StringUtils.isEmpty(bucketUrl) && s3uri.startsWith(bucketUrl)) {
             s3uri = s3uri.replace(bucketUrl, bucketUrl + ".s3.eu-west-1.amazonaws.com");
         }
         return s3uri;

--- a/src/main/java/dp/handler/Handler.java
+++ b/src/main/java/dp/handler/Handler.java
@@ -353,11 +353,17 @@ public class Handler {
         return details.getDownloadURI();
     }
 
-    public String getS3URL(String url) {
-        if (StringUtils.isEmpty(bucketUrl) || StringUtils.isEmpty(bucketS3Url)) {
-            return url;
+    /** 
+     * getS3URL returns an S3-compatible version of url:
+     * replaces the CloudFront/S3 bucket URL (bucketUrl) prefix in url
+     * with the more S3-lib-friendly prefix (bucketS3Url).
+     * Both vars must be non-empty for the replacement to occur.
+     */
+    String getS3URL(String url) {
+        if (StringUtils.isNotEmpty(bucketUrl) && StringUtils.isNotEmpty(bucketS3Url)) {
+            url = url.replace(bucketUrl, bucketS3Url);
         }
-        return url.replace(bucketUrl, bucketS3Url);
+        return url;
     }
 
     public void setBucketS3Url(String newBucketS3Url) {

--- a/src/main/java/dp/handler/Handler.java
+++ b/src/main/java/dp/handler/Handler.java
@@ -167,7 +167,7 @@ public class Handler {
       }
     }
 
-    private String getSafeS3URL(String url) {
+    public String getSafeS3URL(String url) {
         String s3uri = url;
         if (!StringUtils.isEmpty(bucketUrl) && s3uri.startsWith(bucketUrl)) {
             s3uri = s3uri.replace(bucketUrl, bucketUrl + ".s3.eu-west-1.amazonaws.com");

--- a/src/test/java/dp/handler/HandlerTest.java
+++ b/src/test/java/dp/handler/HandlerTest.java
@@ -158,20 +158,23 @@ public class HandlerTest {
     }
 
     @Test
-    public void appendS3uri() throws Exception {
-        handler.setBucketUrl("test-bucket");
+    public void usesS3uri() throws Exception {
+        handler.setBucketUrl("http://bucket");
+        handler.setBucketS3Url("s3://s3-bucket-url");
 
-        String s3uri = handler.getSafeS3URL("test-bucket");
+        String s3uri = handler.getS3URL("http://bucket/test");
 
-        assertThat("correctly appends the s3uri value", s3uri, equalTo("test-bucket.s3.eu-west-1.amazonaws.com"));
+        assertThat("correctly uses the bucketS3URL value", s3uri, equalTo("s3://s3-bucket-url/test"));
 
+        handler.setBucketS3Url("");
         handler.setBucketUrl("");
     }
 
-    public void doesNotappendS3uri() throws Exception {
-        String s3uri = handler.getSafeS3URL("test-bucket");
+    @Test
+    public void doesNotUseS3uri() throws Exception {
+        String s3uri = handler.getS3URL("test-bucket");
 
-        assertThat("correctly appends the s3uri value", s3uri, equalTo("test-bucket"));
+        assertThat("correctly avoids empty bucketS3URL value", s3uri, equalTo("test-bucket"));
     }
 
     @Test

--- a/src/test/java/dp/handler/HandlerTest.java
+++ b/src/test/java/dp/handler/HandlerTest.java
@@ -110,7 +110,6 @@ public class HandlerTest {
     @Before
     public void setUp() {
         MockitoAnnotations.initMocks(this);
-        handler.setBucketUrl(bucketURL);
     }
 
     @Test
@@ -156,6 +155,23 @@ public class HandlerTest {
         assertThat("public URL should be empty", downLoadArguments.getValue().getXls().getPublicState(), equalTo(null));
         assertThat("incorrect bucket name", arguments.getValue().getBucketName(), equalTo("csv-exported"));
         assertThat("incorrect filename", arguments.getValue().getKey(), equalTo("full-datasets/morty.xlsx"));
+    }
+
+    @Test
+    public void appendS3uri() throws Exception {
+        handler.setBucketUrl("test-bucket");
+
+        String s3uri = handler.getSafeS3URL("test-bucket");
+
+        assertThat("correctly appends the s3uri value", s3uri, equalTo("test-bucket.s3.eu-west-1.amazonaws.com"));
+
+        handler.setBucketUrl("");
+    }
+
+    public void doesNotappendS3uri() throws Exception {
+        String s3uri = handler.getSafeS3URL("test-bucket");
+
+        assertThat("correctly appends the s3uri value", s3uri, equalTo("test-bucket"));
     }
 
     @Test


### PR DESCRIPTION
### What

Manipulate the CSV url from kafka message - replacing prefix `S3_BUCKET_URL` with `S3_BUCKET_S3_URL` - for downloading using an s3-compatible URL.

### How to review

Check changes make sense, should handle two cases where
- either env var is empty (no replacement in the s3URL) or
- both env vars have values (where the former is replaced by the latter)

prior to calling AmazonS3URI from aws s3 java library

deploy with https://github.com/ONSdigital/dp-configs/pull/59

### Who can review

Dave or Nathan, ideally