### PR TITLE
updated snake yaml - but is it needed?

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -27,6 +27,12 @@
     </properties>
 
     <dependencies>
+        <!-- Forcing spring-boot-starter V2.4.5 to use the current latest version of snakeyml -->
+        <dependency>
+            <groupId>org.yaml</groupId>
+            <artifactId>snakeyaml</artifactId>
+            <version>1.28</version>
+        </dependency>
         <dependency>
             <groupId>org.springframework.vault</groupId>
             <artifactId>spring-vault-core</artifactId>


### PR DESCRIPTION
### Card
The card states that a score of 7.5 was given against this repo, however running `make audit` on the develop branch has a score of 5.5, so I think this card should be deleted.
https://trello.com/c/v0WJWRLv/10-dp-dataset-exporter-xlsx-snakeyaml-s2-snakeyaml-s2

### What
So I've bumped the version of snakeyaml to the latest (1.28) however I'm not sure this is a good idea, as this is a transitive dependency of spring-boot-starter V2.4.5.  So if we bump the version of spring-boot-starter in the future, and it uses a version of snakeyaml higher than 1.28, this app will continue to use version 1.28, unless this change is removed.

### How to review
It would be useful to know how the vulnerability score of 7.5 was identified.  What tool was used, as Sonotype doesn't give that score.  I've created a draft PR for this.

### Who can review
Anyone with knowledge of Java Maven.