### PR TITLE
Reset traceId value for each new kefka message

### DIFF
--- a/src/main/java/dp/handler/Handler.java
+++ b/src/main/java/dp/handler/Handler.java
@@ -114,6 +114,7 @@ public class Handler {
 
     @KafkaListener(topics = "${KAFKA_TOPIC:common-output-created}")
     public void listen(final ExportedFile message) {
+        info().traceID(null);
         MessageType messageType = GetMessageType(message);
 
         try {

--- a/src/main/java/dp/handler/Handler.java
+++ b/src/main/java/dp/handler/Handler.java
@@ -114,7 +114,11 @@ public class Handler {
 
     @KafkaListener(topics = "${KAFKA_TOPIC:common-output-created}")
     public void listen(final ExportedFile message) {
+        // reset traceID every time that we receive a new Kafka Message
+        // This should be part of dp-logging, which should handle Kafka Messages in a more elegant way,
+        // similarly to how it handles HTTP requests at the moment.
         info().traceID(null);
+
         MessageType messageType = GetMessageType(message);
 
         try {


### PR DESCRIPTION
### What

- Generate a new traceId for each new Kafka message being handled.

### How to review

- Make sure code change makes sense
- Make sure unit tests pass

(info only) This was tested locally by commenting the rest of the handler, adding a few logs before and after the traceId(null), and sending kafka messages to topic. I validated that a new trace Id was generated for each message being handled.

### Who can review

Anyone
