### PR TITLE
fix for group hashcode collisions and unit tests to prove changes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -30,7 +30,7 @@
         <dependency>
             <groupId>org.springframework.vault</groupId>
             <artifactId>spring-vault-core</artifactId>
-            <version>1.1.1.RELEASE</version>
+            <version>2.3.2</version>
         </dependency>
         <dependency>
             <groupId>com.github.ONSdigital</groupId>
@@ -170,6 +170,17 @@
                     <!-- if CVSS >= 7.0 (high or critical) then ERROR else WARN -->
                     <fail>true</fail>
                     <cvssScoreThreshold>7.0</cvssScoreThreshold>
+                    <excludeCoordinates>
+                        <!--
+                            Trello card
+                            https://trello.com/c/im9ku6Vw/2108-orgspringframeworkspring-corejar536compile-audit-failure
+                        -->
+                        <exlude>
+                            <groupId>org.springframework</groupId>
+                            <artifactId>spring-core</artifactId>
+                            <version>5.3.6</version>
+                        </exlude>
+                    </excludeCoordinates>
                 </configuration>
             </plugin>
 

--- a/src/main/java/dp/xlsx/DimensionData.java
+++ b/src/main/java/dp/xlsx/DimensionData.java
@@ -54,4 +54,9 @@ public class DimensionData implements Comparable<DimensionData> {
     public int compareTo(DimensionData o) {
         return this.getValue().compareTo(o.getValue());
     }
+
+    @Override
+    public String toString() {
+        return code + "|" + value;
+    }
 }

--- a/src/main/java/dp/xlsx/Group.java
+++ b/src/main/java/dp/xlsx/Group.java
@@ -2,13 +2,12 @@ package dp.xlsx;
 
 import dp.api.dataset.models.CodeList;
 import dp.api.dataset.models.Metadata;
-import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.builder.EqualsBuilder;
 
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.stream.Collectors;
 
 public class Group implements Comparable<Group> {
 
@@ -81,35 +80,23 @@ public class Group implements Comparable<Group> {
 
     @Override
     public int hashCode() {
-        /**
-         * Generate a string representation of the group by concatinating the string values of each
-         * {@link DimensionData}. The hashcode of this string is the hashcode for this object.
-         *
-         * Explanation:
-         * The previous hashcode implementation for {@link Group} used the hash code of the
-         * {@link Group}{@link #getGroupValues()} but this hashcode was not specific enough when two
-         * {@link DimensionData} objects had very similar values.
-         *
-         * The Group objects created from the following CSV rows although different were generating the same hashcode
-         * value:
-         *
-         *      ,.,1978-to-2018-19,1978 to 2018-19,K02000001,United Kingdom,18,18,gross-income,Gross income,1990s,1990s
-         *      ,.,1978-to-2018-19,1978 to 2018-19,K02000001,United Kingdom,19,19,gross-income,Gross income,1980s,1980s
-         *
-         * This hashcode collision resulted in the {@link V4File} incorrecting parsing the V4 file leading to missing
-         * rows or rows with incorrect observations being assigned.
-         * This slightly wierd approach attempts to address that problem. See GroupTest for me details.
-         */
-        return StringUtils.join(getGroupValues()
-                .stream()
-                .map(val -> val.toString())
-                .collect(Collectors.toList()), "|")
-                .hashCode();
+        return getGroupValues().hashCode();
     }
 
+
+    /**
+     * 2 groups are considered to be equal if their {@link Group#getGroupValues()} are equal. The obeservation values
+     * are not considered as part of the equality check.
+     */
     @Override
-    public boolean equals(Object object) {
-        return this.hashCode() == object.hashCode();
+    public boolean equals(final Object o) {
+        if (this == o) return true;
+
+        if (o == null || this.getClass() != o.getClass()) return false;
+
+        final Group group = (Group) o;
+
+        return new EqualsBuilder().append(this.getGroupValues(), group.getGroupValues()).isEquals();
     }
 
     protected List<DimensionData> getGroupValues() {

--- a/src/main/java/dp/xlsx/Group.java
+++ b/src/main/java/dp/xlsx/Group.java
@@ -1,17 +1,27 @@
 package dp.xlsx;
 
+import dp.api.dataset.models.CodeList;
+import dp.api.dataset.models.Metadata;
+import org.apache.commons.lang3.StringUtils;
+
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-
-import dp.api.dataset.models.CodeList;
-import dp.api.dataset.models.Metadata;
+import java.util.stream.Collectors;
 
 public class Group implements Comparable<Group> {
 
     private List<DimensionData> groupValues; // the unique dimension options
     private Map<String, Observation> observations; // <time, observation>
+
+    /**
+     * Construct a new Group from the provided parameters.
+     */
+    Group(final List<DimensionData> groupValues, final Map<String, Observation> observations) {
+        this.groupValues = groupValues;
+        this.observations = observations;
+    }
 
     /**
      * Gather relevant cells from a csv row. There is a variation of approach for a
@@ -21,7 +31,7 @@ public class Group implements Comparable<Group> {
      * @param data   A row from a V4 file
      * @param offset The v4 file offset
      */
-     Group(String[] data, int offset, Metadata datasetMetadata) {
+    Group(String[] data, int offset, Metadata datasetMetadata) {
 
         final int labelOffset = 2; // Skip the code and get the label when iterating columns
         groupValues = new ArrayList<>();
@@ -44,7 +54,7 @@ public class Group implements Comparable<Group> {
                 }
             }
 
-            String code = data[i -1];
+            String code = data[i - 1];
 
             if (i == columnOffset) {
                 getGroupValues().add(new DimensionData(DimensionType.GEOGRAPHY, label, code));
@@ -57,8 +67,8 @@ public class Group implements Comparable<Group> {
     /**
      * Add a observation into the group
      *
-     * @param timeLabel   The label used for the time
-     * @param observation The observation value
+     * @param timeLabel        The label used for the time
+     * @param observation      The observation value
      * @param additionalValues The addition values which are related to the observation
      */
     void addObservation(final String timeLabel, final String observation, final String[] additionalValues) {
@@ -71,7 +81,30 @@ public class Group implements Comparable<Group> {
 
     @Override
     public int hashCode() {
-        return getGroupValues().hashCode();
+        /**
+         * Generate a string representation of the group by concatinating the string values of each
+         * {@link DimensionData}. The hashcode of this string is the hashcode for this object.
+         *
+         * Explanation:
+         * The previous hashcode implementation for {@link Group} used the hash code of the
+         * {@link Group}{@link #getGroupValues()} but this hashcode was not specific enough when two
+         * {@link DimensionData} objects had very similar values.
+         *
+         * The Group objects created from the following CSV rows although different were generating the same hashcode
+         * value:
+         *
+         *      ,.,1978-to-2018-19,1978 to 2018-19,K02000001,United Kingdom,18,18,gross-income,Gross income,1990s,1990s
+         *      ,.,1978-to-2018-19,1978 to 2018-19,K02000001,United Kingdom,19,19,gross-income,Gross income,1980s,1980s
+         *
+         * This hashcode collision resulted in the {@link V4File} incorrecting parsing the V4 file leading to missing
+         * rows or rows with incorrect observations being assigned.
+         * This slightly wierd approach attempts to address that problem. See GroupTest for me details.
+         */
+        return StringUtils.join(getGroupValues()
+                .stream()
+                .map(val -> val.toString())
+                .collect(Collectors.toList()), "|")
+                .hashCode();
     }
 
     @Override
@@ -103,5 +136,9 @@ public class Group implements Comparable<Group> {
         }
 
         return compared;
+    }
+
+    public Map<String, Observation> getObservations() {
+        return this.observations;
     }
 }

--- a/src/main/java/dp/xlsx/V4File.java
+++ b/src/main/java/dp/xlsx/V4File.java
@@ -2,18 +2,27 @@ package dp.xlsx;
 
 import com.univocity.parsers.csv.CsvParser;
 import com.univocity.parsers.csv.CsvParserSettings;
+import dp.api.dataset.models.Metadata;
 import org.springframework.util.StringUtils;
 
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
-
 import java.text.DateFormat;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
-import java.util.*;
-import dp.api.dataset.models.Metadata;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.TreeMap;
 
 /**
  * A class used to extract information from a V4 file.

--- a/src/test/java/dp/xlsx/DebugUtil.java
+++ b/src/test/java/dp/xlsx/DebugUtil.java
@@ -1,0 +1,37 @@
+package dp.xlsx;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
+
+public class DebugUtil {
+
+    public static Predicate<Group> dimMatcher(final String code, final String val) {
+        return (Group g) -> g.getGroupValues()
+                .stream()
+                .filter(d -> d.getDimensionType().equals(DimensionType.OTHER) && d.getCode().equals(code) && d.getValue().equals(val))
+                .findFirst()
+                .isPresent();
+    }
+
+    public static List<Group> filterGroups(Collection<Group> input, Predicate<Group> filter) {
+        return input
+                .stream()
+                .filter(g -> filter.test(g))
+                .collect(Collectors.toList());
+    }
+
+    public static void display(List<Group> groups) {
+        System.out.println(groups.size() + " entries");
+        groups.stream().forEach(entry -> displayGroup(entry));
+    }
+
+    public static void displayGroup(Group g) {
+        System.out.println(g.getGroupValues() + " " + g.getObservations()
+                .entrySet()
+                .stream()
+                .map(e -> e.getKey() + " " + e.getValue().getValue())
+                .collect(Collectors.toList()));
+    }
+}

--- a/src/test/java/dp/xlsx/GroupTest.java
+++ b/src/test/java/dp/xlsx/GroupTest.java
@@ -48,12 +48,12 @@ public class GroupTest {
 
     @Test
     public void testEquals_twoObjectWithSameValues_shouldBeEqual() {
-        Group dupplicate = new Group(new ArrayList<DimensionData>() {{
+        Group duplicate = new Group(new ArrayList<DimensionData>() {{
             add(new DimensionData(DimensionType.GEOGRAPHY, "K02000001", "K02000001"));
             add(new DimensionData(DimensionType.OTHER, "cpi1dim1G20100", "02.1 Alcoholic beverages"));
         }}, null);
 
-        assertThat(alcoholicBeverages).isEqualTo(dupplicate);
+        assertThat(alcoholicBeverages).isEqualTo(duplicate);
     }
 
     @Test
@@ -63,11 +63,11 @@ public class GroupTest {
 
     @Test
     public void testHashCode_twoEqualObjects_shouldProduceEqualHashcode() {
-        Group dupplicate = new Group(new ArrayList<DimensionData>() {{
+        Group duplicate = new Group(new ArrayList<DimensionData>() {{
             add(new DimensionData(DimensionType.GEOGRAPHY, "K02000001", "K02000001"));
             add(new DimensionData(DimensionType.OTHER, "cpi1dim1G20100", "02.1 Alcoholic beverages"));
         }}, null);
 
-        assertThat(alcoholicBeverages).isEqualTo(dupplicate);
+        assertThat(alcoholicBeverages.hashCode()).isEqualTo(duplicate.hashCode());
     }
 }

--- a/src/test/java/dp/xlsx/GroupTest.java
+++ b/src/test/java/dp/xlsx/GroupTest.java
@@ -1,55 +1,73 @@
 package dp.xlsx;
 
+import org.junit.Before;
 import org.junit.Test;
 
 import java.util.ArrayList;
-import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class GroupTest {
 
-    @Test
-    public void test_hashCode_verySimilarDimensions_shouldHaveDifferentCodes() throws Exception {
-        List<DimensionData> rowOne = new ArrayList<DimensionData>() {{
+    private Group indirectTaxesAge18The90s;
+    private Group indirectTaxesAge19The80s;
+    private Group clothing;
+    private Group alcoholicBeverages;
+
+    @Before
+    public void setup() {
+        indirectTaxesAge18The90s = new Group(new ArrayList<DimensionData>() {{
             add(new DimensionData(DimensionType.GEOGRAPHY, "United Kingdom", "K02000001"));
             add(new DimensionData(DimensionType.OTHER, "18", "18"));
             add(new DimensionData(DimensionType.OTHER, "Indirect taxes", "indirect-taxes"));
             add(new DimensionData(DimensionType.OTHER, "1990s", "1990s"));
-        }};
+        }}, null);
 
-        List<DimensionData> rowTwo = new ArrayList<DimensionData>() {{
+        indirectTaxesAge19The80s = new Group(new ArrayList<DimensionData>() {{
             add(new DimensionData(DimensionType.GEOGRAPHY, "United Kingdom", "K02000001"));
             add(new DimensionData(DimensionType.OTHER, "19", "19"));
             add(new DimensionData(DimensionType.OTHER, "Indirect taxes", "indirect-taxes"));
             add(new DimensionData(DimensionType.OTHER, "1980s", "1980s"));
-        }};
+        }}, null);
 
-        Group groupOne = new Group(rowOne, null);
-        Group groupTwo = new Group(rowTwo, null);
+        clothing = new Group(new ArrayList<DimensionData>() {{
+            add(new DimensionData(DimensionType.GEOGRAPHY, "K02000001", "K02000001"));
+            add(new DimensionData(DimensionType.OTHER, "cpi1dim1G30100", "03.1 Clothing"));
+        }}, null);
 
-        assertThat(groupOne.hashCode()).isNotEqualTo(groupTwo.hashCode());
+        alcoholicBeverages = new Group(new ArrayList<DimensionData>() {{
+            add(new DimensionData(DimensionType.GEOGRAPHY, "K02000001", "K02000001"));
+            add(new DimensionData(DimensionType.OTHER, "cpi1dim1G20100", "02.1 Alcoholic beverages"));
+        }}, null);
     }
 
     @Test
-    public void test_hashCode_sameDimensions_shouldHaveTheSameCode() throws Exception {
-        List<DimensionData> rowOne = new ArrayList<DimensionData>() {{
-            add(new DimensionData(DimensionType.GEOGRAPHY, "United Kingdom", "K02000001"));
-            add(new DimensionData(DimensionType.OTHER, "18", "18"));
-            add(new DimensionData(DimensionType.OTHER, "Indirect taxes", "indirect-taxes"));
-            add(new DimensionData(DimensionType.OTHER, "1990s", "1990s"));
-        }};
+    public void testEquals_verySimilarDimensions_shouldNotBeEqual() throws Exception {
+        assertThat(indirectTaxesAge18The90s).isNotEqualTo(indirectTaxesAge19The80s);
+    }
 
-        List<DimensionData> rowTwo = new ArrayList<DimensionData>() {{
-            add(new DimensionData(DimensionType.GEOGRAPHY, "United Kingdom", "K02000001"));
-            add(new DimensionData(DimensionType.OTHER, "18", "18"));
-            add(new DimensionData(DimensionType.OTHER, "Indirect taxes", "indirect-taxes"));
-            add(new DimensionData(DimensionType.OTHER, "1990s", "1990s"));
-        }};
+    @Test
+    public void testEquals_twoObjectWithSameValues_shouldBeEqual() {
+        Group dupplicate = new Group(new ArrayList<DimensionData>() {{
+            add(new DimensionData(DimensionType.GEOGRAPHY, "K02000001", "K02000001"));
+            add(new DimensionData(DimensionType.OTHER, "cpi1dim1G20100", "02.1 Alcoholic beverages"));
+        }}, null);
 
-        Group groupOne = new Group(rowOne, null);
-        Group groupTwo = new Group(rowTwo, null);
+        assertThat(alcoholicBeverages).isEqualTo(dupplicate);
+    }
 
-        assertThat(groupOne.hashCode()).isEqualTo(groupTwo.hashCode());
+    @Test
+    public void testEquals_twoObjectWithDifferentValues_shouldNotBeEqual() {
+        assertThat(clothing).isNotEqualTo(alcoholicBeverages);
+    }
+
+    @Test
+    public void testHashCode_twoEqualObjects_shouldProduceEqualHashcode() {
+        Group dupplicate = new Group(new ArrayList<DimensionData>() {{
+            add(new DimensionData(DimensionType.GEOGRAPHY, "K02000001", "K02000001"));
+            add(new DimensionData(DimensionType.OTHER, "cpi1dim1G20100", "02.1 Alcoholic beverages"));
+        }}, null);
+
+        assertThat(alcoholicBeverages).isEqualTo(dupplicate);
     }
 }

--- a/src/test/java/dp/xlsx/GroupTest.java
+++ b/src/test/java/dp/xlsx/GroupTest.java
@@ -1,0 +1,55 @@
+package dp.xlsx;
+
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class GroupTest {
+
+    @Test
+    public void test_hashCode_verySimilarDimensions_shouldHaveDifferentCodes() throws Exception {
+        List<DimensionData> rowOne = new ArrayList<DimensionData>() {{
+            add(new DimensionData(DimensionType.GEOGRAPHY, "United Kingdom", "K02000001"));
+            add(new DimensionData(DimensionType.OTHER, "18", "18"));
+            add(new DimensionData(DimensionType.OTHER, "Indirect taxes", "indirect-taxes"));
+            add(new DimensionData(DimensionType.OTHER, "1990s", "1990s"));
+        }};
+
+        List<DimensionData> rowTwo = new ArrayList<DimensionData>() {{
+            add(new DimensionData(DimensionType.GEOGRAPHY, "United Kingdom", "K02000001"));
+            add(new DimensionData(DimensionType.OTHER, "19", "19"));
+            add(new DimensionData(DimensionType.OTHER, "Indirect taxes", "indirect-taxes"));
+            add(new DimensionData(DimensionType.OTHER, "1980s", "1980s"));
+        }};
+
+        Group groupOne = new Group(rowOne, null);
+        Group groupTwo = new Group(rowTwo, null);
+
+        assertThat(groupOne.hashCode()).isNotEqualTo(groupTwo.hashCode());
+    }
+
+    @Test
+    public void test_hashCode_sameDimensions_shouldHaveTheSameCode() throws Exception {
+        List<DimensionData> rowOne = new ArrayList<DimensionData>() {{
+            add(new DimensionData(DimensionType.GEOGRAPHY, "United Kingdom", "K02000001"));
+            add(new DimensionData(DimensionType.OTHER, "18", "18"));
+            add(new DimensionData(DimensionType.OTHER, "Indirect taxes", "indirect-taxes"));
+            add(new DimensionData(DimensionType.OTHER, "1990s", "1990s"));
+        }};
+
+        List<DimensionData> rowTwo = new ArrayList<DimensionData>() {{
+            add(new DimensionData(DimensionType.GEOGRAPHY, "United Kingdom", "K02000001"));
+            add(new DimensionData(DimensionType.OTHER, "18", "18"));
+            add(new DimensionData(DimensionType.OTHER, "Indirect taxes", "indirect-taxes"));
+            add(new DimensionData(DimensionType.OTHER, "1990s", "1990s"));
+        }};
+
+        Group groupOne = new Group(rowOne, null);
+        Group groupTwo = new Group(rowTwo, null);
+
+        assertThat(groupOne.hashCode()).isEqualTo(groupTwo.hashCode());
+    }
+}

--- a/src/test/java/dp/xlsx/V4FileTest.java
+++ b/src/test/java/dp/xlsx/V4FileTest.java
@@ -8,7 +8,10 @@ import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
+import java.util.function.Predicate;
 
+import static dp.xlsx.DebugUtil.dimMatcher;
+import static dp.xlsx.DebugUtil.filterGroups;
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class V4FileTest {
@@ -144,4 +147,33 @@ public class V4FileTest {
 
         }
     }
+
+    @Test
+    public void shouldCreateTheExpectedGroupMapping() throws IOException {
+        try (final InputStream stream = V4FileTest.class.getResourceAsStream("v4_2_generational_income.csv")) {
+            final V4File file = new V4File(stream, null);
+
+            // 36 csv rows should translate to 36 groups for this dataset.
+            assertThat(file.groupData().size()).isEqualTo(36);
+
+            Predicate<Group> filter = dimMatcher("19", "19")
+                    .and(dimMatcher("1980s", "1980s"))
+                    .and(dimMatcher("gross-income", "Gross income"));
+
+            List<Group> results = filterGroups(file.groupData(), filter);
+
+            assertThat(results.size()).isEqualTo(1);
+            assertThat(results.get(0).getObservation("1978 to 2018-19").getValue()).isEqualTo("14854");
+
+            filter = dimMatcher("18", "18")
+                    .and(dimMatcher("1990s", "1990s"))
+                    .and(dimMatcher("gross-income", "Gross income"));
+
+            results = filterGroups(file.groupData(), filter);
+
+            assertThat(results.size()).isEqualTo(1);
+            assertThat(results.get(0).getObservation("1978 to 2018-19").getValue()).isEqualTo("");
+        }
+    }
+
 }

--- a/src/test/resources/dp/xlsx/v4_2_generational_income.csv
+++ b/src/test/resources/dp/xlsx/v4_2_generational_income.csv
@@ -1,0 +1,37 @@
+V4_1,Data Marking,yyyy-yy,Time,uk-only,Geography,single-year-of-age,Age,tax-benefit-type,TypeOfTaxOrBenefit,decade,Decade
+8093,,1978-to-2018-19,1978 to 2018-19,K02000001,United Kingdom,19,19,post-tax-income,Post-tax income,1980s,1980s
+6356,,1978-to-2018-19,1978 to 2018-19,K02000001,United Kingdom,18,18,cash-benefits,Cash benefits,1980s,1980s
+3669,,1978-to-2018-19,1978 to 2018-19,K02000001,United Kingdom,18,18,indirect-taxes,Indirect taxes,1980s,1980s
+5029,,1978-to-2018-19,1978 to 2018-19,K02000001,United Kingdom,19,19,indirect-taxes,Indirect taxes,1980s,1980s
+17438,,1978-to-2018-19,1978 to 2018-19,K02000001,United Kingdom,18,18,final-income,Final income,1980s,1980s
+1704,,1978-to-2018-19,1978 to 2018-19,K02000001,United Kingdom,18,18,direct-taxes,Direct taxes,1980s,1980s
+1732,,1978-to-2018-19,1978 to 2018-19,K02000001,United Kingdom,19,19,direct-taxes,Direct taxes,1980s,1980s
+13978,,1978-to-2018-19,1978 to 2018-19,K02000001,United Kingdom,18,18,disposable-income,Disposable income,1980s,1980s
+4060,,1978-to-2018-19,1978 to 2018-19,K02000001,United Kingdom,19,19,cash-benefits,Cash benefits,1980s,1980s
+14854,,1978-to-2018-19,1978 to 2018-19,K02000001,United Kingdom,19,19,gross-income,Gross income,1980s,1980s
+15682,,1978-to-2018-19,1978 to 2018-19,K02000001,United Kingdom,18,18,gross-income,Gross income,1980s,1980s
+13122,,1978-to-2018-19,1978 to 2018-19,K02000001,United Kingdom,19,19,disposable-income,Disposable income,1980s,1980s
+9326,,1978-to-2018-19,1978 to 2018-19,K02000001,United Kingdom,18,18,original-income,Original income,1980s,1980s
+10309,,1978-to-2018-19,1978 to 2018-19,K02000001,United Kingdom,18,18,post-tax-income,Post-tax income,1980s,1980s
+18312,,1978-to-2018-19,1978 to 2018-19,K02000001,United Kingdom,19,19,final-income,Final income,1980s,1980s
+10794,,1978-to-2018-19,1978 to 2018-19,K02000001,United Kingdom,19,19,original-income,Original income,1980s,1980s
+7129,,1978-to-2018-19,1978 to 2018-19,K02000001,United Kingdom,18,18,benefits-in-kind,Benefits-in-kind,1980s,1980s
+10219,,1978-to-2018-19,1978 to 2018-19,K02000001,United Kingdom,19,19,benefits-in-kind,Benefits-in-kind,1980s,1980s
+8515,,1978-to-2018-19,1978 to 2018-19,K02000001,United Kingdom,19,19,post-tax-income,Post-tax income,1990s,1990s
+7721,,1978-to-2018-19,1978 to 2018-19,K02000001,United Kingdom,19,19,original-income,Original income,1990s,1990s
+13739,,1978-to-2018-19,1978 to 2018-19,K02000001,United Kingdom,19,19,gross-income,Gross income,1990s,1990s
+6018,,1978-to-2018-19,1978 to 2018-19,K02000001,United Kingdom,19,19,cash-benefits,Cash benefits,1990s,1990s
+,.,1978-to-2018-19,1978 to 2018-19,K02000001,United Kingdom,18,18,gross-income,Gross income,1990s,1990s
+,.,1978-to-2018-19,1978 to 2018-19,K02000001,United Kingdom,18,18,benefits-in-kind,Benefits-in-kind,1990s,1990s
+,.,1978-to-2018-19,1978 to 2018-19,K02000001,United Kingdom,18,18,cash-benefits,Cash benefits,1990s,1990s
+,.,1978-to-2018-19,1978 to 2018-19,K02000001,United Kingdom,18,18,original-income,Original income,1990s,1990s
+,.,1978-to-2018-19,1978 to 2018-19,K02000001,United Kingdom,18,18,direct-taxes,Direct taxes,1990s,1990s
+,.,1978-to-2018-19,1978 to 2018-19,K02000001,United Kingdom,18,18,post-tax-income,Post-tax income,1990s,1990s
+17022,,1978-to-2018-19,1978 to 2018-19,K02000001,United Kingdom,19,19,final-income,Final income,1990s,1990s
+12576,,1978-to-2018-19,1978 to 2018-19,K02000001,United Kingdom,19,19,disposable-income,Disposable income,1990s,1990s
+4061,,1978-to-2018-19,1978 to 2018-19,K02000001,United Kingdom,19,19,indirect-taxes,Indirect taxes,1990s,1990s
+,.,1978-to-2018-19,1978 to 2018-19,K02000001,United Kingdom,18,18,disposable-income,Disposable income,1990s,1990s
+,.,1978-to-2018-19,1978 to 2018-19,K02000001,United Kingdom,18,18,final-income,Final income,1990s,1990s
+8507,,1978-to-2018-19,1978 to 2018-19,K02000001,United Kingdom,19,19,benefits-in-kind,Benefits-in-kind,1990s,1990s
+1163,,1978-to-2018-19,1978 to 2018-19,K02000001,United Kingdom,19,19,direct-taxes,Direct taxes,1990s,1990s
+,.,1978-to-2018-19,1978 to 2018-19,K02000001,United Kingdom,18,18,indirect-taxes,Indirect taxes,1990s,1990s


### PR DESCRIPTION
### Defect

Filtering the `Generational Income` dataset was producing incorrect results, rows missing and some rows with the wrong observation values.

We traced this to an incorrect `equals()` implementation in `Group` class. The previous `equals` method was comparing hashcodes to determine equality - this is incorrect. 

A `HashMap` essentially uses a hash code to determined which bucket to search in and then uses the object's `equals()` method to find the correct item for the requested key.

In this case the equals method was using the hashcode code to determine equality which resulted in _false positives_ for cases where 2 objects where **not equal** but generated the same hash code value.

Hash code collisions are completely valid but the HashMap impl relies on the equals method to correctly identify which object to return. As this was incorrect it resulted in the wrong objects being returned from the map which in turn lead to rows missing from the XLSX file or rows with the wrong observation value.


### Also
Added exclusion for audit failure. I updated to the latest version but this is also affected by the same failure so I've added an exclude and created a trello ticket to follow up.