### PR TITLE
disable kafka auto-commit and increase KAFKA_POLL_TIMEOUT

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,8 @@ Scripts for updating and debugging Kafka can be found [here](https://github.com/
 | KAFKA_ADDR                  | localhost:9092                       | Kafka address to use
 | KAFKA_GROUP                 | dp-dataset-exporter-xlsx             | Kafka consumer group name
 | KAFKA_TOPIC                 | common-output-created                | Kafka topic to listen to
+| KAFKA_POLL_MAX_RECORDS      | 1                                    | Maximum number of Kafka messages that will be consumed each time
+| KAFKA_POLL_TIMEOUT          | 60000                                | Timeout to process a single Kafka message, after this time the consumer is considered failed and the group will rebalance in order to reassign the partitions to another member
 | KAFKA_SEC_PROTO             | _unset_                              | if set to "TLS", kafka connections will use TLS
 | KAFKA_SEC_CLIENT_KEY        | _unset_                              | if using TLS (see above), this is the path to the keystore (optional, used for client auth) - only used if `KAFKA_SEC_CLIENT_KEY_P12` is unset
 | KAFKA_SEC_CLIENT_KEY_P12    | _unset_                              | if using TLS (see above), this is a base64-encoded PKCS12 keystore (optional, used for client auth)

--- a/README.md
+++ b/README.md
@@ -30,8 +30,9 @@ Scripts for updating and debugging Kafka can be found [here](https://github.com/
 | KAFKA_ADDR                  | localhost:9092                       | Kafka address to use
 | KAFKA_GROUP                 | dp-dataset-exporter-xlsx             | Kafka consumer group name
 | KAFKA_TOPIC                 | common-output-created                | Kafka topic to listen to
-| KAFKA_POLL_MAX_RECORDS      | 1                                    | Maximum number of Kafka messages that will be consumed each time
-| KAFKA_POLL_TIMEOUT          | 60000                                | Timeout to process a single Kafka message, after this time the consumer is considered failed and the group will rebalance in order to reassign the partitions to another member
+| KAFKA_POLL_MAX_RECORDS      | 1                                    | Maximum number of Kafka messages that will be consumed each time (batch).
+| KAFKA_POLL_TIMEOUT          | 120000                               | Timeout to process a batch of Kafka messages, after this time the consumer is considered failed and the group will rebalance in order to reassign the partitions to another member. This value must be greater than the maximum expected time to process a batch of messages.
+| KAFKA_SESSION_TIMEOUT       | 10000                                | The timeout used to detect client failures when using Kafka's group management facility, this value may be smaller than the time to process a message.
 | KAFKA_SEC_PROTO             | _unset_                              | if set to "TLS", kafka connections will use TLS
 | KAFKA_SEC_CLIENT_KEY        | _unset_                              | if using TLS (see above), this is the path to the keystore (optional, used for client auth) - only used if `KAFKA_SEC_CLIENT_KEY_P12` is unset
 | KAFKA_SEC_CLIENT_KEY_P12    | _unset_                              | if using TLS (see above), this is a base64-encoded PKCS12 keystore (optional, used for client auth)

--- a/src/main/java/dp/configuration/KafkaConfiguration.java
+++ b/src/main/java/dp/configuration/KafkaConfiguration.java
@@ -44,13 +44,14 @@ public class KafkaConfiguration {
 
     // maximum number of kafka records returned in a single call when consumer talks to the kafka topic.
     // default to one, because each kafka message will potentially need to perform a long operation
-    // (create and upload one XLSX file)
     @Value("${KAFKA_POLL_MAX_RECORDS:1}")
     private int kafkaPollMaxRecords;
 
-    // default to 1 min This value should be greater than the maximum expected time to process a message
-    // (create and upload one XLSX file)
-    private static final int POLL_TIMEOUT = 60000;
+    // this value should be greater than the maximum expected time to process each message.
+    // default to one minute
+    @Value("${KAFKA_POLL_TIMEOUT:60000}")
+    private int kafkaPollTimeout;
+
     private static final String KEY_FILE_PREFIX = "client-key";
 
     /**
@@ -64,7 +65,7 @@ public class KafkaConfiguration {
         Map<String, Object> props = new HashMap<>();
         props.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, kafkaAddress);
         props.put(ConsumerConfig.GROUP_ID_CONFIG, kafkaGroup);
-        props.put(ConsumerConfig.MAX_POLL_INTERVAL_MS_CONFIG, POLL_TIMEOUT);
+        props.put(ConsumerConfig.MAX_POLL_INTERVAL_MS_CONFIG, kafkaPollTimeout);
         props.put(ConsumerConfig.MAX_POLL_RECORDS_CONFIG, kafkaPollMaxRecords);
         props.put(ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG, false);
 

--- a/src/main/java/dp/configuration/KafkaConfiguration.java
+++ b/src/main/java/dp/configuration/KafkaConfiguration.java
@@ -42,15 +42,24 @@ public class KafkaConfiguration {
     @Value("${KAFKA_GROUP:dp-dataset-exporter-xlsx}")
     private String kafkaGroup;
 
-    // maximum number of kafka records returned in a single call when consumer talks to the kafka topic.
-    // default to one, because each kafka message will potentially need to perform a long operation
+    // maximum number of kafka records returned in a single poll.
+    // default to one, because each kafka message will potentially need to perform a long operation.
     @Value("${KAFKA_POLL_MAX_RECORDS:1}")
     private int kafkaPollMaxRecords;
 
-    // this value should be greater than the maximum expected time to process each message.
-    // default to one minute
-    @Value("${KAFKA_POLL_TIMEOUT:60000}")
+    // maximum time allowed for a batch to be processed
+    // this value should be greater than the maximum expected time to process each message times KAFKA_POLL_MAX_RECORDS
+    // default to 2 minutes.
+    // note: new messages will be consumed straight away after one is completed, not every KAFKA_POLL_TIMEOUT period.
+    @Value("${KAFKA_POLL_TIMEOUT:120000}")
     private int kafkaPollTimeout;
+
+    // maximum period of time between heartbeats for the consumer to be considered healthy
+    // this value may be smaller than the maximum expected time to process a message.
+    // this value should be between the broker's values for group.min.session.timeout.ms (default: 6000)
+    // and group.max.session.timeout.ms (default: 30000)
+    @Value("${KAFKA_SESSION_TIMEOUT:10000}")
+    private int kafkaSessionTimeout;
 
     private static final String KEY_FILE_PREFIX = "client-key";
 
@@ -65,6 +74,7 @@ public class KafkaConfiguration {
         Map<String, Object> props = new HashMap<>();
         props.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, kafkaAddress);
         props.put(ConsumerConfig.GROUP_ID_CONFIG, kafkaGroup);
+        props.put(ConsumerConfig.SESSION_TIMEOUT_MS_CONFIG, kafkaSessionTimeout);
         props.put(ConsumerConfig.MAX_POLL_INTERVAL_MS_CONFIG, kafkaPollTimeout);
         props.put(ConsumerConfig.MAX_POLL_RECORDS_CONFIG, kafkaPollMaxRecords);
         props.put(ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG, false);

--- a/src/test/java/dp/handler/HandlerTest.java
+++ b/src/test/java/dp/handler/HandlerTest.java
@@ -33,6 +33,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.kafka.support.Acknowledgment;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.vault.authentication.SessionManager;
@@ -99,6 +100,9 @@ public class HandlerTest {
     @Mock
     private VaultResponse vaultResponse;
 
+    @Mock
+    private Acknowledgment ack;
+
     private String instanceID = "inst123";
     private String datasetID = "ds456";
     private String edition = "2017";
@@ -141,7 +145,7 @@ public class HandlerTest {
         final ExportedFile exportedFile = new ExportedFile("", "s3://bucket/datasets/v4.csv", instanceID, datasetID, edition,
                 version, filename, rowCount);
 
-        handler.listen(exportedFile);
+        handler.listen(exportedFile, ack);
 
         verify(datasetAPI, times(1)).getVersion("/instances/" + instanceID);
         verify(datasetAPI, times(1)).putVersionDownloads(any(), downLoadArguments.capture());
@@ -200,7 +204,7 @@ public class HandlerTest {
                 "instbuckUrl", "dsbuckUrl", edition, version, "filenamebuckUrl", rowCount);
 
         handler.setBucketUrl("https://not-empty");
-        handler.listen(exportedFile);
+        handler.listen(exportedFile, ack);
 
         verify(datasetAPI, times(1)).getVersion("/instances/instbuckUrl");
         verify(datasetAPI, times(1)).getMetadata("/datasets/dsbuckUrl/editions/2017/versions/1");
@@ -241,7 +245,7 @@ public class HandlerTest {
                                 "instFiltbuckUrl", "dsFiltbuckUrl", edition, version, "filenameFiltbuckUrl.xlsx", rowCount);
 
         handler.setBucketUrl("https://not-empty");
-        handler.listen(exportedFile);
+        handler.listen(exportedFile, ack);
 
         verify(workbookMock, times(1)).write(any(OutputStream.class));
 
@@ -264,7 +268,7 @@ public class HandlerTest {
         final ExportedFile exportedFile = new ExportedFile("", "s3://bucket/datasets/v4.csv", instanceID, datasetID, edition,
                 version, filename, 500000000);
 
-        handler.listen(exportedFile);
+        handler.listen(exportedFile, ack);
 
         verify(datasetAPI, never()).getVersion("/instances/" + instanceID);
         verify(datasetAPI, never()).putVersionDownloads(any(), any());
@@ -292,7 +296,7 @@ public class HandlerTest {
 
         final ExportedFile exportedFile = new ExportedFile("inst123", "s3://bucket/v4.csv", "12345", "cpih", "2018", "1", "", rowCount);
 
-        handler.listen(exportedFile);
+        handler.listen(exportedFile, ack);
 
         verify(s3Client, times(1)).getObject(anyString(), anyString());
         verify(filterAPI, times(1)).getFilter(exportedFile.getFilterId().toString());
@@ -314,7 +318,7 @@ public class HandlerTest {
 
         final ExportedFile exportedFile = new ExportedFile("inst123", "s3://bucket/v4.csv", "12345", "", "", "", "", 500000000);
 
-        handler.listen(exportedFile);
+        handler.listen(exportedFile, ack);
 
         verify(filterAPI, never()).getFilter(exportedFile.getFilterId().toString());
         verify(filterAPI, times(1)).setToComplete(exportedFile.getFilterId().toString());
@@ -338,7 +342,7 @@ public class HandlerTest {
 
         final ExportedFile exportedFile = new ExportedFile("inst123", "s3://bucket/v4.csv", "12345", "", "", "", "", rowCount);
 
-        handler.listen(exportedFile);
+        handler.listen(exportedFile, ack);
 
         verify(s3Client, times(1)).getObject(anyString(), anyString());
         verify(filterAPI, times(1)).getFilter(exportedFile.getFilterId().toString());
@@ -364,7 +368,7 @@ public class HandlerTest {
 
         final ExportedFile exportedFile = new ExportedFile("inst123", "s3://bucket/v4.csv", "12345", "", "", "", "", rowCount);
 
-        handler.listen(exportedFile);
+        handler.listen(exportedFile, ack);
 
         verify(s3Client, times(1)).getObject(anyString(), anyString());
         verify(filterAPI, times(1)).getFilter(exportedFile.getFilterId().toString());
@@ -392,7 +396,7 @@ public class HandlerTest {
 
         final ExportedFile exportedFile = new ExportedFile("inst123", "s3://bucket/v4.csv", "12345", "", "", "", "", rowCount);
 
-        handler.listen(exportedFile);
+        handler.listen(exportedFile, ack);
 
         verify(s3Client, times(1)).getObject(anyString(), anyString());
         verify(filterAPI, times(1)).getFilter(exportedFile.getFilterId().toString());
@@ -423,7 +427,7 @@ public class HandlerTest {
 
         final ExportedFile exportedFile = new ExportedFile("inst123", "s3://bucket/v4.csv", "12345", "ASHE-8", "2019", "1", "", rowCount);
 
-        handler.listen(exportedFile);
+        handler.listen(exportedFile, ack);
 
         verify(s3Client, times(1)).getObject(anyString(), anyString());
         verify(filterAPI, times(1)).getFilter(exportedFile.getFilterId().toString());
@@ -460,7 +464,7 @@ public class HandlerTest {
 
         final ExportedFile exportedFile = new ExportedFile("inst123", "s3://bucket/v4.csv", "12345", "cpih01", "2020", "11", "", rowCount);
 
-        handler.listen(exportedFile);
+        handler.listen(exportedFile, ack);
 
         verify(s3Client, times(1)).getObject(anyString(), anyString());
         verify(filterAPI, times(1)).getFilter(exportedFile.getFilterId().toString());
@@ -495,7 +499,7 @@ public class HandlerTest {
         final ExportedFile exportedFile = new ExportedFile("", "s3://bucket/v4.csv", instanceID, datasetID, edition,
                 version, filename, rowCount);
 
-        handler.listen(exportedFile);
+        handler.listen(exportedFile, ack);
 
 		verify(datasetAPI, times(1)).getVersion(anyString());
 		verify(datasetAPI, times(1)).getMetadata(versionURL);
@@ -522,7 +526,7 @@ public class HandlerTest {
         final ExportedFile exportedFile = new ExportedFile("", "s3://bucket/v4.csv", instanceID, datasetID, edition,
                 version, filename, rowCount);
 
-        handler.listen(exportedFile);
+        handler.listen(exportedFile, ack);
 
         verify(datasetAPI, times(1)).getVersion(anyString());
         verify(s3Client, times(1)).getObject(bucketURL, "v4.csv");
@@ -547,7 +551,7 @@ public class HandlerTest {
         final ExportedFile exportedFile = new ExportedFile("", "s3://bucket/v4.csv", instanceID, datasetID, edition,
                 version, filename, rowCount);
 
-        handler.listen(exportedFile);
+        handler.listen(exportedFile, ack);
 
         verify(datasetAPI, times(1)).getVersion(anyString());
         verify(s3Client, times(1)).getObject(bucketURL, "v4.csv");
@@ -574,7 +578,7 @@ public class HandlerTest {
         final ExportedFile exportedFile = new ExportedFile("", "s3://bucket/v4.csv", instanceID, datasetID, edition,
                 version, filename, rowCount);
 
-        handler.listen(exportedFile);
+        handler.listen(exportedFile, ack);
 
         verify(datasetAPI, times(1)).getVersion(anyString());
         verify(s3Client, times(1)).getObject(bucketURL, "v4.csv");
@@ -596,7 +600,7 @@ public class HandlerTest {
         final ExportedFile exportedFile = new ExportedFile("", "s3://bucket/v4.csv", instanceID, datasetID, edition,
                 version, filename, rowCount);
 
-        handler.listen(exportedFile);
+        handler.listen(exportedFile, ack);
 
         verify(datasetAPI, times(1)).getVersion(anyString());
         verify(s3Client, never()).getObject(bucketURL, "v4.csv");
@@ -630,7 +634,7 @@ public class HandlerTest {
         final ExportedFile exportedFile = new ExportedFile("", "s3://bucket/v4.csv", instanceID, datasetID, edition,
                 version, filename, rowCount);
 
-        handler.listen(exportedFile);
+        handler.listen(exportedFile, ack);
 
         verify(datasetAPI, times(1)).getVersion(anyString());
         verify(s3Client, times(1)).getObject(bucketURL, "v4.csv");
@@ -671,7 +675,7 @@ public class HandlerTest {
         final ExportedFile exportedFile = new ExportedFile("inst123", "s3://bucket/v4.csv", "", "", "", "", "", rowCount);
 
         try {
-            handler.listen(exportedFile);
+            handler.listen(exportedFile, ack);
         } catch (Exception e) {
             verify(datasetAPI, times(1)).getVersion(anyString());
             verify(s3Client, times(1)).getObject(anyString(), anyString());


### PR DESCRIPTION
### What

Bugfix: dataset XLSX exporter replicating messages. Trello card: https://trello.com/c/DZzWxddR/5436-unable-to-download-filter-outputs-s2

- Disable auto-commit
- Always commit the message in Handler.listen(), regardless of errors

- Created new config env var `KAFKA_POLL_TIMEOUT` and increased the default to 120000 (2 minutes) - this value should be greater than the maximum time expected for a batch of messages to be processed.
If KAFKA_POLL_TIMEOUT is too low we see a loop of the following errors:
```sh
  "raw" : "[Consumer clientId=consumer-dp-dataset-exporter-xlsx-1, groupId=dp-dataset-exporter-xlsx] Member consumer-dp-dataset-exporter-xlsx-1-f7767171-bade-4bd9-bf06-1afd937126e5 sending LeaveGroup request to coordinator localhost:9092 (id: 2147483646 rack: null) due to consumer poll timeout has expired. This means the time between subsequent calls to poll() was longer than the configured max.poll.interval.ms, which typically implies that the poll loop is spending too much time processing messages. You can address this either by increasing max.poll.interval.ms or by reducing the maximum size of batches returned in poll() with max.poll.records."
```

- Set `KAFKA_POLL_MAX_RECORDS` default value to 1 and validate that messages are consumed straight away, without waiting for KAFKA_POLL_TIMEOUT.

- Add `KAFKA_SESSION_TIMEOUT` to control the consumer's heartbeat timeout independently from the poll period.

### How to review

- Make sure code changes make sense
- Make sure unit tests pass

#### Local testing info, no need to replicate

Tested locally by:
- replacing the the try block in `Handler.listen` with a `process()` method to try different scenarios
- creating a testing producer
- running a kafka cluster, this service, and the testing producer.
- sending messages from the testing producer

---- test process and kill ----

```golang
private void process(ExportedFile message) throws Exception {
    info().filterID(message.getFilterId().toString()).log("start processing message...");
    Thread.sleep(10000); // 10s
    info().filterID(message.getFilterId().toString()).log("message processed");
}
```

1- make debug, wait until running
2- send a kafka message
3- ctrl+c before it finishes processing
4- make debug
5- see it consume the same message again (it was not committed)


---- test out of memory ----
```golang
private void process(ExportedFile message) throws Exception {
    info().filterID(message.getFilterId().toString()).log("start processing message...");
    List<byte[]> list = new ArrayList<>();
    while (true) {
        // 1MB each loop, 1 x 1024 x 1024 = 1048576
        byte[] b = new byte[1048576];
        list.add(b);
    }
}
```

1- make debug, wait until running
2- send a kafka message
3- see the process dies with Error: "message" : "java.lang.OutOfMemoryError: Java heap space"
4- make debug
5- see the message is not consumed again (it was committed)

---- test exceptions ---

```golang
private void process(ExportedFile message) throws Exception {
    info().filterID(message.getFilterId().toString()).log("start processing message...");
    int r = ThreadLocalRandom.current().nextInt(0, 100 + 1);
    if(r < 20) {
        throw new FilterAPIException("filter api exception", null);
    }
    if (r < 40) {
        throw new Exception("generic exception");
    }
    info().filterID(message.getFilterId().toString()).log("message processed");
}
```

1- make debug, wait until running
2- send a kafka message
3A- see the message is consumed successfully (no error)
3B- see the app logs an error: "message" : "dp.exceptions.FilterAPIException: filter api exception"
3C- see the app logs an error: "message" : "java.lang.Exception: generic exception"
4- see the message is not consumed again (it was committed)

---- test multiple messages ---

1 - produce 3 messages
2- see that they are consumed straight away one after the other, regardless of the poll period

---- test multiple messages with batch ---

1- set KAFKA_POLL_MAX_RECORDS=5
2- set KAFKA_POLL_TIMEOUT=25000
3- produce 5 messages, each sleeping 10s
4- see that 2 messages are correclty processed, but after the third, we see the following error:
```
"message" : "org.springframework.kafka.listener.ListenerExecutionFailedException: Listener method 'public void dp.handler.Handler.listen(dp.avro.ExportedFile,org.springframework.kafka.support.Acknowledgment)' threw exception; nested exception is org.apache.kafka.clients.consumer.CommitFailedException: Offset commit cannot be completed since the consumer is not part of an active group for auto partition assignment; it is likely that the consumer was kicked out of the group.; nested exception is org.apache.kafka.clients.consumer.CommitFailedException: Offset commit cannot be completed since the consumer is not part of an active group for auto partition assignment; it is likely that the consumer was kicked out of the group."
```

### Who can review

anyone
